### PR TITLE
Feat: route, map, swap, list polish

### DIFF
--- a/android/.env.example
+++ b/android/.env.example
@@ -5,3 +5,14 @@
 SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_ANON_KEY=your-anon-key-here
 API_BASE_URL=http://10.0.2.2:8000
+
+# Mapbox runtime access token (pk.* public token) -- used by the app at runtime
+# to authorize map tile loads and Directions API calls. Shared with iOS.
+MAPBOX_ACCESS_TOKEN=
+
+# Mapbox downloads token (sk.* secret) -- required by Gradle to pull the
+# Mapbox Maps SDK from api.mapbox.com. Distinct from the runtime token.
+# Generate one at https://account.mapbox.com/access-tokens/ with the
+# "Downloads:Read" secret scope. Can also be supplied via the
+# MAPBOX_DOWNLOADS_TOKEN environment variable instead of .env.
+MAPBOX_DOWNLOADS_TOKEN=

--- a/android/.env.example
+++ b/android/.env.example
@@ -4,3 +4,4 @@
 
 SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_ANON_KEY=your-anon-key-here
+API_BASE_URL=http://10.0.2.2:8000

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -72,6 +72,9 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.play.services.location)
+    implementation(libs.kotlinx.coroutines.play.services)
+    implementation(libs.coil.compose)
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
 
     // Jetpack Compose

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -22,6 +22,7 @@ android {
         var supabaseUrl = "https://placeholder.supabase.co"
         var supabaseAnonKey = ""
         var apiBaseUrl = ""
+        var mapboxAccessToken = ""
         if (envFile.exists()) {
             envFile.readLines()
                 .filter { it.contains("=") && !it.trim().startsWith("#") }
@@ -32,6 +33,7 @@ android {
                             "SUPABASE_URL" -> supabaseUrl = parts[1].trim().removeSurrounding("\"")
                             "SUPABASE_ANON_KEY" -> supabaseAnonKey = parts[1].trim().removeSurrounding("\"")
                             "API_BASE_URL" -> apiBaseUrl = parts[1].trim().removeSurrounding("\"")
+                            "MAPBOX_ACCESS_TOKEN" -> mapboxAccessToken = parts[1].trim().removeSurrounding("\"")
                         }
                     }
                 }
@@ -39,6 +41,7 @@ android {
         buildConfigField("String", "SUPABASE_URL", "\"${supabaseUrl.replace("\"", "\\\"")}\"")
         buildConfigField("String", "SUPABASE_ANON_KEY", "\"${supabaseAnonKey.replace("\"", "\\\"")}\"")
         buildConfigField("String", "API_BASE_URL", "\"${apiBaseUrl.replace("\"", "\\\"")}\"")
+        buildConfigField("String", "MAPBOX_ACCESS_TOKEN", "\"${mapboxAccessToken.replace("\"", "\\\"")}\"")
     }
 
     buildTypes {
@@ -75,6 +78,8 @@ dependencies {
     implementation(libs.play.services.location)
     implementation(libs.kotlinx.coroutines.play.services)
     implementation(libs.coil.compose)
+    implementation(libs.mapbox.android)
+    implementation(libs.mapbox.compose)
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
 
     // Jetpack Compose

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -105,6 +105,8 @@ dependencies {
     implementation(libs.ktor.client.serialization.json)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.kotlinx.serialization.json)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:allowBackup="true"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Android"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,10 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
+        android:name=".NeighborlyApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/android/app/src/main/java/com/example/android/MainActivity.kt
+++ b/android/app/src/main/java/com/example/android/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.example.android.data.api.KtorNeighborlyApi
 import com.example.android.data.connectivity.ConnectivityManagerNetworkMonitor
 import com.example.android.data.local.SharedPreferencesGroceryListLocalDataSource
 import com.example.android.data.local.preferences.SharedPreferencesPreferenceRepository
@@ -35,7 +36,8 @@ class MainActivity : ComponentActivity() {
                         SharedPreferencesGroceryListLocalDataSource(app.applicationContext)
                     ),
                     preferenceRepository = SharedPreferencesPreferenceRepository(app.applicationContext),
-                    networkMonitor = ConnectivityManagerNetworkMonitor(app.applicationContext)
+                    networkMonitor = ConnectivityManagerNetworkMonitor(app.applicationContext),
+                    api = KtorNeighborlyApi()
                 )
             }
         }

--- a/android/app/src/main/java/com/example/android/MainActivity.kt
+++ b/android/app/src/main/java/com/example/android/MainActivity.kt
@@ -7,6 +7,12 @@ import androidx.activity.viewModels
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.example.android.data.connectivity.ConnectivityManagerNetworkMonitor
+import com.example.android.data.local.SharedPreferencesGroceryListLocalDataSource
+import com.example.android.data.local.preferences.SharedPreferencesPreferenceRepository
+import com.example.android.data.repository.GroceryListRepository
 import com.example.android.ui.AppScaffold
 import com.example.android.ui.theme.NeighborlyTheme
 import com.example.android.ui.login.LoginScreen
@@ -17,7 +23,21 @@ import com.example.android.viewmodel.shopper.ShopperViewModel
 class MainActivity : ComponentActivity() {
     private val loginViewModel: LoginViewModel by viewModels()
     private val homeViewModel: HomeViewModel by viewModels()
-    private val shopperViewModel: ShopperViewModel by viewModels()
+    private val shopperViewModel: ShopperViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                val app = application
+                ShopperViewModel(
+                    application = app,
+                    groceryListRepository = GroceryListRepository(
+                        SharedPreferencesGroceryListLocalDataSource(app.applicationContext)
+                    ),
+                    preferenceRepository = SharedPreferencesPreferenceRepository(app.applicationContext),
+                    networkMonitor = ConnectivityManagerNetworkMonitor(app.applicationContext)
+                )
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android/app/src/main/java/com/example/android/MainActivity.kt
+++ b/android/app/src/main/java/com/example/android/MainActivity.kt
@@ -18,11 +18,13 @@ import com.example.android.ui.theme.NeighborlyTheme
 import com.example.android.ui.login.LoginScreen
 import com.example.android.viewmodel.home.HomeViewModel
 import com.example.android.viewmodel.login.LoginViewModel
+import com.example.android.viewmodel.route.RouteViewModel
 import com.example.android.viewmodel.shopper.ShopperViewModel
 
 class MainActivity : ComponentActivity() {
     private val loginViewModel: LoginViewModel by viewModels()
     private val homeViewModel: HomeViewModel by viewModels()
+    private val routeViewModel: RouteViewModel by viewModels()
     private val shopperViewModel: ShopperViewModel by viewModels {
         viewModelFactory {
             initializer {
@@ -49,7 +51,8 @@ class MainActivity : ComponentActivity() {
                         AppScaffold(
                             loginViewModel = loginViewModel,
                             homeViewModel = homeViewModel,
-                            shopperViewModel = shopperViewModel
+                            shopperViewModel = shopperViewModel,
+                            routeViewModel = routeViewModel
                         )
                     } else {
                         LoginScreen(viewModel = loginViewModel)

--- a/android/app/src/main/java/com/example/android/NeighborlyApp.kt
+++ b/android/app/src/main/java/com/example/android/NeighborlyApp.kt
@@ -1,0 +1,18 @@
+package com.example.android
+
+import android.app.Application
+import com.mapbox.common.MapboxOptions
+
+/**
+ * Application entry point. Sets the runtime Mapbox access token before any
+ * `MapView` / `MapboxMap` is constructed, mirroring the iOS `AppConfig`
+ * `mapboxAccessToken` setup.
+ */
+class NeighborlyApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        if (BuildConfig.MAPBOX_ACCESS_TOKEN.isNotBlank()) {
+            MapboxOptions.accessToken = BuildConfig.MAPBOX_ACCESS_TOKEN
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/android/data/api/NeighborlyApi.kt
+++ b/android/app/src/main/java/com/example/android/data/api/NeighborlyApi.kt
@@ -43,7 +43,10 @@ interface NeighborlyApi {
     suspend fun optimizeRoute(
         productIds: List<String>,
         userLat: Double? = null,
-        userLng: Double? = null
+        userLng: Double? = null,
+        mode: String? = null,
+        maxStops: Int? = null,
+        maxRadiusMiles: Double? = null
     ): Result<OptimizedRoute>
 
     suspend fun getAlternatives(productId: String): Result<List<Product>>
@@ -102,7 +105,10 @@ class KtorNeighborlyApi(
     override suspend fun optimizeRoute(
         productIds: List<String>,
         userLat: Double?,
-        userLng: Double?
+        userLng: Double?,
+        mode: String?,
+        maxStops: Int?,
+        maxRadiusMiles: Double?
     ): Result<OptimizedRoute> = request {
         post {
             neighborlyUrl("routes", "optimize")
@@ -111,7 +117,10 @@ class KtorNeighborlyApi(
                 OptimizeRouteRequest(
                     productIds = productIds,
                     userLat = userLat,
-                    userLng = userLng
+                    userLng = userLng,
+                    mode = mode,
+                    maxStops = maxStops,
+                    maxRadiusMiles = maxRadiusMiles
                 )
             )
         }

--- a/android/app/src/main/java/com/example/android/data/connectivity/NetworkMonitor.kt
+++ b/android/app/src/main/java/com/example/android/data/connectivity/NetworkMonitor.kt
@@ -1,0 +1,76 @@
+package com.example.android.data.connectivity
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import androidx.core.content.getSystemService
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+/**
+ * Observes device connectivity. Mirrors iOS `NetworkMonitor` (NWPathMonitor wrapper).
+ */
+interface NetworkMonitor {
+    /**
+     * Emits `true` when the device has an internet-capable network, `false` otherwise.
+     * Always emits the current state on collection start.
+     */
+    val isOnline: Flow<Boolean>
+}
+
+/**
+ * `NetworkMonitor` implementation backed by `ConnectivityManager.NetworkCallback`.
+ * Tracks the set of currently-available networks so brief switches between Wi-Fi
+ * and cellular do not flicker `false` between `onLost`/`onAvailable`.
+ */
+class ConnectivityManagerNetworkMonitor(
+    private val context: Context
+) : NetworkMonitor {
+    override val isOnline: Flow<Boolean> = callbackFlow {
+        val connectivityManager = context.getSystemService<ConnectivityManager>()
+        if (connectivityManager == null) {
+            trySend(false)
+            close()
+            return@callbackFlow
+        }
+
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            private val activeNetworks = mutableSetOf<Network>()
+
+            override fun onAvailable(network: Network) {
+                activeNetworks += network
+                trySend(true)
+            }
+
+            override fun onLost(network: Network) {
+                activeNetworks -= network
+                trySend(activeNetworks.isNotEmpty())
+            }
+
+            override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+                val online = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+                    capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                if (online) activeNetworks += network else activeNetworks -= network
+                trySend(activeNetworks.isNotEmpty())
+            }
+        }
+
+        // Seed with current state so the first emission reflects reality, not the
+        // first callback that happens to fire.
+        val current = connectivityManager.activeNetwork
+            ?.let(connectivityManager::getNetworkCapabilities)
+            ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+        trySend(current)
+
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        connectivityManager.registerNetworkCallback(request, callback)
+
+        awaitClose { connectivityManager.unregisterNetworkCallback(callback) }
+    }.distinctUntilChanged()
+}

--- a/android/app/src/main/java/com/example/android/data/location/LocationHelper.kt
+++ b/android/app/src/main/java/com/example/android/data/location/LocationHelper.kt
@@ -1,0 +1,45 @@
+package com.example.android.data.location
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.CurrentLocationRequest
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withTimeoutOrNull
+
+data class UserCoordinates(val latitude: Double, val longitude: Double)
+
+interface LocationHelper {
+    fun hasPermission(): Boolean
+    suspend fun requestLastKnownLocation(timeoutMs: Long = 3_000L): UserCoordinates?
+}
+
+class FusedLocationHelper(
+    private val context: Context,
+    private val client: FusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(context)
+) : LocationHelper {
+    override fun hasPermission(): Boolean {
+        val fine = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+        val coarse = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
+        return fine || coarse
+    }
+
+    @Suppress("MissingPermission")
+    override suspend fun requestLastKnownLocation(timeoutMs: Long): UserCoordinates? {
+        if (!hasPermission()) return null
+        return runCatching {
+            withTimeoutOrNull(timeoutMs) {
+                val request = CurrentLocationRequest.Builder()
+                    .setPriority(Priority.PRIORITY_BALANCED_POWER_ACCURACY)
+                    .setMaxUpdateAgeMillis(60_000L)
+                    .build()
+                val location = client.getCurrentLocation(request, null).await() ?: return@withTimeoutOrNull null
+                UserCoordinates(location.latitude, location.longitude)
+            }
+        }.getOrNull()
+    }
+}

--- a/android/app/src/main/java/com/example/android/data/maps/MapboxDirectionsService.kt
+++ b/android/app/src/main/java/com/example/android/data/maps/MapboxDirectionsService.kt
@@ -1,0 +1,138 @@
+package com.example.android.data.maps
+
+import com.example.android.BuildConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.serialization.JsonConvertException
+import io.ktor.serialization.kotlinx.json.json
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * A single leg returned from the Mapbox Directions API. Distances are in
+ * meters and durations in seconds, matching the API contract directly so the
+ * caller can compute its own ETAs (e.g. `max(1, duration / 60)` minutes).
+ */
+data class DirectionsLeg(
+    val distanceMeters: Double,
+    val durationSeconds: Double
+)
+
+/**
+ * Walking directions result. `coordinates` is the full GeoJSON line geometry
+ * decoded into (latitude, longitude) pairs for direct rendering on a map. Per
+ * the iOS implementation we request `geometries=geojson&overview=full`.
+ */
+data class DirectionsResult(
+    val coordinates: List<Pair<Double, Double>>,
+    val legs: List<DirectionsLeg>
+)
+
+/**
+ * Lightweight client for the Mapbox Directions API, matching the iOS
+ * `MapboxDirectionsService.getWalkingRoute` contract.
+ *
+ * Waypoints are passed as `(longitude, latitude)` pairs to mirror the Mapbox
+ * URL convention (`{lng,lat;lng,lat;...}`).
+ */
+interface MapboxDirectionsService {
+    suspend fun walkingRoute(waypoints: List<Pair<Double, Double>>): Result<DirectionsResult>
+}
+
+class KtorMapboxDirectionsService(
+    private val accessToken: String = BuildConfig.MAPBOX_ACCESS_TOKEN,
+    private val client: HttpClient = defaultHttpClient()
+) : MapboxDirectionsService {
+
+    override suspend fun walkingRoute(
+        waypoints: List<Pair<Double, Double>>
+    ): Result<DirectionsResult> {
+        if (waypoints.size < 2) {
+            return Result.failure(IllegalArgumentException("Need at least 2 waypoints"))
+        }
+        if (accessToken.isBlank()) {
+            return Result.failure(IllegalStateException("MAPBOX_ACCESS_TOKEN is not set"))
+        }
+
+        val coordString = waypoints.joinToString(";") { (lng, lat) -> "$lng,$lat" }
+        val url = "https://api.mapbox.com/directions/v5/mapbox/walking/$coordString" +
+            "?geometries=geojson&overview=full&steps=false&access_token=$accessToken"
+
+        return try {
+            val response: HttpResponse = client.get(url)
+            if (!response.status.isSuccess()) {
+                return Result.failure(
+                    RuntimeException("Mapbox Directions HTTP ${response.status.value}: ${response.safeBody()}")
+                )
+            }
+            val payload: DirectionsResponse = response.body()
+            val route = payload.routes.firstOrNull()
+                ?: return Result.failure(RuntimeException("Mapbox Directions returned no routes"))
+
+            val coords = route.geometry.coordinates.mapNotNull { pair ->
+                if (pair.size >= 2) pair[1] to pair[0] else null // GeoJSON is [lng,lat]
+            }
+            val legs = route.legs.map {
+                DirectionsLeg(distanceMeters = it.distance, durationSeconds = it.duration)
+            }
+            Result.success(DirectionsResult(coordinates = coords, legs = legs))
+        } catch (cancel: CancellationException) {
+            throw cancel
+        } catch (io: IOException) {
+            Result.failure(io)
+        } catch (decode: JsonConvertException) {
+            Result.failure(decode)
+        } catch (decode: SerializationException) {
+            Result.failure(decode)
+        } catch (other: Throwable) {
+            Result.failure(other)
+        }
+    }
+
+    private suspend fun HttpResponse.safeBody(): String? =
+        runCatching { bodyAsText().takeIf { it.isNotBlank() } }.getOrNull()
+
+    @Serializable
+    private data class DirectionsResponse(val routes: List<RouteDto> = emptyList())
+
+    @Serializable
+    private data class RouteDto(
+        val geometry: GeometryDto,
+        val legs: List<LegDto> = emptyList()
+    )
+
+    @Serializable
+    private data class GeometryDto(val coordinates: List<List<Double>> = emptyList())
+
+    @Serializable
+    private data class LegDto(val distance: Double, val duration: Double)
+
+    companion object {
+        fun defaultHttpClient(): HttpClient = HttpClient(Android) {
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        explicitNulls = false
+                    }
+                )
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 15_000
+                connectTimeoutMillis = 10_000
+                socketTimeoutMillis = 15_000
+            }
+            expectSuccess = false
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/android/data/model/Product.kt
+++ b/android/app/src/main/java/com/example/android/data/model/Product.kt
@@ -35,35 +35,45 @@ data class ProductCategory(
     val slug: String
 ) {
     val emoji: String
-        get() = when (slug) {
-            "milk" -> "🥛"
-            "water" -> "💧"
-            "yogurt" -> "🥄"
-            "bread" -> "🍞"
-            "chicken" -> "🍗"
-            "turkey" -> "🦃"
-            "cereal" -> "🥣"
-            "eggs" -> "🥚"
-            "cheese" -> "🧀"
-            "fresh-fruit" -> "🍎"
-            "fresh-vegetables" -> "🥬"
-            "pasta-rice-grains" -> "🍝"
-            "chips" -> "🍿"
-            "canned-packaged-foods" -> "🥫"
-            "frozen-vegetables" -> "🥦"
-            "bakery" -> "🥐"
-            "beverages" -> "🥤"
-            "breakfast" -> "🥞"
-            "deli" -> "🥪"
-            "frozen" -> "❄️"
-            "international" -> "🌍"
-            "meatandseafood" -> "🥩"
-            "pantry" -> "🫙"
-            "produce" -> "🥕"
-            "refrigerated" -> "🧊"
-            "snacks" -> "🍿"
-            else -> "🛒"
-        }
+        get() = categoryEmojiForSlug(slug)
+}
+
+/**
+ * Maps a category slug to its display emoji. Used by both the [ProductCategory.emoji]
+ * extension (when the full category object is available) and by route-list rendering
+ * (where only a slug string is carried on `RouteStopItem`).
+ *
+ * Falls back to "🛒" — same default as [ProductImage]'s fallback emoji — for an
+ * unknown or null slug.
+ */
+fun categoryEmojiForSlug(slug: String?): String = when (slug) {
+    "milk" -> "🥛"
+    "water" -> "💧"
+    "yogurt" -> "🥄"
+    "bread" -> "🍞"
+    "chicken" -> "🍗"
+    "turkey" -> "🦃"
+    "cereal" -> "🥣"
+    "eggs" -> "🥚"
+    "cheese" -> "🧀"
+    "fresh-fruit" -> "🍎"
+    "fresh-vegetables" -> "🥬"
+    "pasta-rice-grains" -> "🍝"
+    "chips" -> "🍿"
+    "canned-packaged-foods" -> "🥫"
+    "frozen-vegetables" -> "🥦"
+    "bakery" -> "🥐"
+    "beverages" -> "🥤"
+    "breakfast" -> "🥞"
+    "deli" -> "🥪"
+    "frozen" -> "❄️"
+    "international" -> "🌍"
+    "meatandseafood" -> "🥩"
+    "pantry" -> "🫙"
+    "produce" -> "🥕"
+    "refrigerated" -> "🧊"
+    "snacks" -> "🍿"
+    else -> "🛒"
 }
 
 @Serializable

--- a/android/app/src/main/java/com/example/android/data/model/RouteModels.kt
+++ b/android/app/src/main/java/com/example/android/data/model/RouteModels.kt
@@ -49,5 +49,11 @@ data class OptimizeRouteRequest(
     @SerialName("user_lat")
     val userLat: Double? = null,
     @SerialName("user_lng")
-    val userLng: Double? = null
+    val userLng: Double? = null,
+    @SerialName("mode")
+    val mode: String? = null,
+    @SerialName("max_stops")
+    val maxStops: Int? = null,
+    @SerialName("max_radius_miles")
+    val maxRadiusMiles: Double? = null
 )

--- a/android/app/src/main/java/com/example/android/data/repository/GroceryListRepository.kt
+++ b/android/app/src/main/java/com/example/android/data/repository/GroceryListRepository.kt
@@ -19,6 +19,20 @@ data class GroceryProductSummary(
     val imageUrl: String? = null
 )
 
+internal fun Product.toGroceryProductSummary(): GroceryProductSummary {
+    return GroceryProductSummary(
+        productId = id,
+        upc = upc,
+        name = name,
+        brand = brand,
+        unitSize = unitSize,
+        bestPrice = bestPrice,
+        bestStoreName = bestPriceStoreName,
+        categoryEmoji = productCategories.emoji,
+        imageUrl = imageUrl
+    )
+}
+
 interface GroceryProductSearchGateway {
     suspend fun searchProducts(query: String): Result<List<GroceryProductSummary>>
     suspend fun refreshProducts(productIds: List<String>): Result<List<GroceryProductSummary>>
@@ -78,20 +92,6 @@ class ApiGroceryProductSearchGateway(
 
         return Result.success(refreshedProducts)
     }
-
-    private fun Product.toGroceryProductSummary(): GroceryProductSummary {
-        return GroceryProductSummary(
-            productId = id,
-            upc = upc,
-            name = name,
-            brand = brand,
-            unitSize = unitSize,
-            bestPrice = bestPrice,
-            bestStoreName = bestPriceStoreName,
-            categoryEmoji = productCategories.emoji,
-            imageUrl = imageUrl
-        )
-    }
 }
 
 class GroceryListRepository(
@@ -142,6 +142,26 @@ class GroceryListRepository(
         }
         localDataSource.saveItems(updatedItems)
         return updatedItems
+    }
+
+    fun replaceProduct(
+        currentItemId: String,
+        replacement: GroceryProductSummary
+    ): List<GroceryListItemRecord> {
+        val items = localDataSource.loadItems().toMutableList()
+        val index = items.indexOfFirst { it.id == currentItemId }
+        if (index == -1) return items
+        val current = items[index]
+        items[index] = current.copy(
+            productId = replacement.productId,
+            upc = replacement.upc,
+            name = replacement.name,
+            unitSize = replacement.unitSize.ifBlank { current.unitSize },
+            store = replacement.bestStoreName.orEmpty(),
+            price = replacement.bestPrice ?: current.price
+        )
+        localDataSource.saveItems(items)
+        return items
     }
 
     fun deleteItem(id: String): List<GroceryListItemRecord> {

--- a/android/app/src/main/java/com/example/android/data/repository/GroceryListRepository.kt
+++ b/android/app/src/main/java/com/example/android/data/repository/GroceryListRepository.kt
@@ -1,7 +1,10 @@
 package com.example.android.data.repository
 
+import com.example.android.data.api.KtorNeighborlyApi
+import com.example.android.data.api.NeighborlyApi
 import com.example.android.data.local.GroceryListItemRecord
 import com.example.android.data.local.GroceryListLocalDataSource
+import com.example.android.data.model.Product
 import java.util.UUID
 
 data class GroceryProductSummary(
@@ -55,9 +58,45 @@ class LocalFallbackGroceryProductSearchGateway : GroceryProductSearchGateway {
     }
 }
 
+class ApiGroceryProductSearchGateway(
+    private val api: NeighborlyApi = KtorNeighborlyApi()
+) : GroceryProductSearchGateway {
+    override suspend fun searchProducts(query: String): Result<List<GroceryProductSummary>> {
+        return api.searchProducts(query)
+            .map { response -> response.data.map { it.toGroceryProductSummary() } }
+    }
+
+    override suspend fun refreshProducts(productIds: List<String>): Result<List<GroceryProductSummary>> {
+        if (productIds.isEmpty()) return Result.success(emptyList())
+
+        val refreshedProducts = mutableListOf<GroceryProductSummary>()
+        productIds.distinct().forEach { productId ->
+            api.getProduct(productId)
+                .onSuccess { product -> refreshedProducts += product.toGroceryProductSummary() }
+                .onFailure { error -> return Result.failure(error) }
+        }
+
+        return Result.success(refreshedProducts)
+    }
+
+    private fun Product.toGroceryProductSummary(): GroceryProductSummary {
+        return GroceryProductSummary(
+            productId = id,
+            upc = upc,
+            name = name,
+            brand = brand,
+            unitSize = unitSize,
+            bestPrice = bestPrice,
+            bestStoreName = bestPriceStoreName,
+            categoryEmoji = productCategories.emoji,
+            imageUrl = imageUrl
+        )
+    }
+}
+
 class GroceryListRepository(
     private val localDataSource: GroceryListLocalDataSource,
-    private val productSearchGateway: GroceryProductSearchGateway = LocalFallbackGroceryProductSearchGateway()
+    private val productSearchGateway: GroceryProductSearchGateway = ApiGroceryProductSearchGateway()
 ) {
     fun loadItems(): List<GroceryListItemRecord> = localDataSource.loadItems()
 

--- a/android/app/src/main/java/com/example/android/data/repository/preferences/UserPreferences.kt
+++ b/android/app/src/main/java/com/example/android/data/repository/preferences/UserPreferences.kt
@@ -3,7 +3,18 @@ package com.example.android.data.repository.preferences
 enum class OptimizationPriority(val label: String) {
     LowestCost("Lowest Cost"),
     ShortestRoute("Shortest Route"),
-    FastestTrip("Fastest Trip")
+    FastestTrip("Fastest Trip");
+
+    /**
+     * Maps the user-facing priority to the backend `mode` query parameter on
+     * `/routes/optimize`. Mirrors iOS `Priority.backendMode`
+     * (PreferencesView.swift:23-29).
+     */
+    fun toBackendMode(): String = when (this) {
+        LowestCost -> "cost"
+        ShortestRoute -> "distance"
+        FastestTrip -> "stops"
+    }
 }
 
 enum class TransportMode(val label: String) {

--- a/android/app/src/main/java/com/example/android/data/repository/route/ApiRouteRepository.kt
+++ b/android/app/src/main/java/com/example/android/data/repository/route/ApiRouteRepository.kt
@@ -83,7 +83,9 @@ class ApiRouteRepository(
             unitSize = unitSize,
             price = effectivePrice,
             originalPrice = originalPrice,
-            swapAvailable = true
+            swapAvailable = true,
+            imageUrl = imageUrl,
+            categorySlug = categorySlug
         )
     }
 

--- a/android/app/src/main/java/com/example/android/data/repository/route/ApiRouteRepository.kt
+++ b/android/app/src/main/java/com/example/android/data/repository/route/ApiRouteRepository.kt
@@ -1,0 +1,97 @@
+package com.example.android.data.repository.route
+
+import com.example.android.data.api.KtorNeighborlyApi
+import com.example.android.data.api.NeighborlyApi
+import com.example.android.data.model.OptimizedRoute
+import com.example.android.data.model.Product
+import com.example.android.data.model.RouteItem
+import com.example.android.data.model.RouteStop
+import com.example.android.viewmodel.route.OptimizedRouteStop
+import com.example.android.viewmodel.route.RouteMissingItem
+import com.example.android.viewmodel.route.RoutePlan
+import com.example.android.viewmodel.route.RouteStopItem
+
+/**
+ * Production [RouteRepository] backed by [NeighborlyApi]. Maps the raw
+ * `OptimizedRoute` / `Product` DTOs returned by the backend into the domain
+ * types consumed by `RouteViewModel`.
+ *
+ * Errors from the API ([com.example.android.data.api.NeighborlyApiError])
+ * propagate through the underlying [Result] without rewrapping — callers can
+ * still pattern-match on the sealed error type if they need to.
+ */
+class ApiRouteRepository(
+    private val api: NeighborlyApi = KtorNeighborlyApi()
+) : RouteRepository {
+
+    override suspend fun optimizeRoute(
+        productIds: List<String>,
+        userLat: Double?,
+        userLng: Double?,
+        mode: String?,
+        maxStops: Int?,
+        maxRadiusMiles: Double?
+    ): Result<RoutePlan> = api.optimizeRoute(
+        productIds = productIds,
+        userLat = userLat,
+        userLng = userLng,
+        mode = mode,
+        maxStops = maxStops,
+        maxRadiusMiles = maxRadiusMiles
+    ).map { it.toRoutePlan() }
+
+    override suspend fun getSwapAlternatives(productId: String): Result<List<RouteSwapOption>> =
+        api.getAlternatives(productId).map { products ->
+            products.map { it.toSwapOption() }
+        }
+
+    private fun OptimizedRoute.toRoutePlan(): RoutePlan = RoutePlan(
+        totalCost = totalCost,
+        totalDistanceMiles = null,
+        estimatedDurationMinutes = null,
+        savings = null,
+        stops = stops.mapIndexed { index, stop -> stop.toOptimizedRouteStop(index + 1) },
+        missingItems = itemsNotFound.map { name ->
+            RouteMissingItem(
+                productId = null,
+                name = name,
+                reason = null
+            )
+        }
+    )
+
+    private fun RouteStop.toOptimizedRouteStop(index: Int): OptimizedRouteStop =
+        OptimizedRouteStop(
+            index = index,
+            storeId = store.id,
+            storeName = store.name,
+            address = store.address,
+            distanceMiles = null,
+            estimatedDurationMinutes = null,
+            latitude = store.lat,
+            longitude = store.lng,
+            items = items.map { it.toRouteStopItem() }
+        )
+
+    private fun RouteItem.toRouteStopItem(): RouteStopItem {
+        val effectivePrice = salePrice ?: price
+        val originalPrice = if (salePrice != null) price else null
+        return RouteStopItem(
+            productId = productId,
+            name = name,
+            quantity = 1,
+            unitSize = unitSize,
+            price = effectivePrice,
+            originalPrice = originalPrice,
+            swapAvailable = true
+        )
+    }
+
+    private fun Product.toSwapOption(): RouteSwapOption = RouteSwapOption(
+        productId = id,
+        name = name,
+        storeName = bestPriceStoreName,
+        price = bestPrice,
+        reason = null
+    )
+}

--- a/android/app/src/main/java/com/example/android/data/repository/route/RouteRepository.kt
+++ b/android/app/src/main/java/com/example/android/data/repository/route/RouteRepository.kt
@@ -6,7 +6,10 @@ interface RouteRepository {
     suspend fun optimizeRoute(
         productIds: List<String>,
         userLat: Double?,
-        userLng: Double?
+        userLng: Double?,
+        mode: String? = null,
+        maxStops: Int? = null,
+        maxRadiusMiles: Double? = null
     ): Result<RoutePlan>
 
     suspend fun getSwapAlternatives(productId: String): Result<List<RouteSwapOption>>
@@ -21,24 +24,28 @@ data class RouteSwapOption(
 )
 
 /**
- * Temporary Epic C seam while Worker A/B land API and persisted grocery-list plumbing.
- * Replace this with a repository backed by NeighborlyApi.optimizeRoute/getAlternatives.
+ * Fallback / test seam used before [ApiRouteRepository] was wired up. Kept around
+ * so tests and offline scenarios can opt out of network calls without throwing
+ * surprises at runtime — production code should depend on [ApiRouteRepository].
  */
 class UnavailableRouteRepository : RouteRepository {
     override suspend fun optimizeRoute(
         productIds: List<String>,
         userLat: Double?,
-        userLng: Double?
+        userLng: Double?,
+        mode: String?,
+        maxStops: Int?,
+        maxRadiusMiles: Double?
     ): Result<RoutePlan> = Result.failure(
         IllegalStateException(
-            "Route optimization API is not wired yet. Connect NeighborlyApi.optimizeRoute once Epic A4 is available."
+            "Route optimization API is not wired in this build. Inject ApiRouteRepository instead."
         )
     )
 
     override suspend fun getSwapAlternatives(productId: String): Result<List<RouteSwapOption>> =
         Result.failure(
             IllegalStateException(
-                "Swap alternatives API is not wired yet. Connect NeighborlyApi.getAlternatives once Epic A4 is available."
+                "Swap alternatives API is not wired in this build. Inject ApiRouteRepository instead."
             )
         )
 }

--- a/android/app/src/main/java/com/example/android/ui/AppScaffold.kt
+++ b/android/app/src/main/java/com/example/android/ui/AppScaffold.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -53,10 +52,10 @@ private enum class AppDestination {
 fun AppScaffold(
     loginViewModel: LoginViewModel,
     homeViewModel: HomeViewModel,
-    shopperViewModel: ShopperViewModel
+    shopperViewModel: ShopperViewModel,
+    routeViewModel: RouteViewModel
 ) {
     var destination by rememberSaveable { mutableStateOf(AppDestination.Home) }
-    val routeViewModel = remember { RouteViewModel() }
 
     val currentTab = when (destination) {
         AppDestination.Home -> MainTab.Home

--- a/android/app/src/main/java/com/example/android/ui/AppScaffold.kt
+++ b/android/app/src/main/java/com/example/android/ui/AppScaffold.kt
@@ -112,11 +112,14 @@ fun AppScaffold(
 
             AppDestination.Lists -> GroceryListScreen(
                 shopperViewModel = shopperViewModel,
+                routeViewModel = routeViewModel,
+                onNavigateToRoute = { destination = AppDestination.Route },
                 modifier = Modifier.padding(innerPadding)
             )
 
             AppDestination.Route -> RouteScreen(
                 routeViewModel = routeViewModel,
+                shopperViewModel = shopperViewModel,
                 modifier = Modifier.padding(innerPadding)
             )
 

--- a/android/app/src/main/java/com/example/android/ui/components/ProductImage.kt
+++ b/android/app/src/main/java/com/example/android/ui/components/ProductImage.kt
@@ -1,0 +1,54 @@
+package com.example.android.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.SubcomposeAsyncImage
+
+private const val DEFAULT_FALLBACK_EMOJI = "🛒"
+
+@Composable
+fun ProductImage(
+    imageUrl: String?,
+    contentDescription: String?,
+    fallbackEmoji: String = DEFAULT_FALLBACK_EMOJI,
+    modifier: Modifier = Modifier,
+    size: Dp = 48.dp,
+    cornerRadius: Dp = 8.dp,
+) {
+    val shape = RoundedCornerShape(cornerRadius)
+    val container = modifier
+        .size(size)
+        .clip(shape)
+        .background(MaterialTheme.colorScheme.surfaceVariant)
+
+    if (imageUrl.isNullOrBlank()) {
+        EmojiFallback(emoji = fallbackEmoji, modifier = container)
+    } else {
+        SubcomposeAsyncImage(
+            model = imageUrl,
+            contentDescription = contentDescription,
+            modifier = container,
+            contentScale = ContentScale.Crop,
+            loading = { EmojiFallback(emoji = fallbackEmoji, modifier = Modifier) },
+            error = { EmojiFallback(emoji = fallbackEmoji, modifier = Modifier) },
+        )
+    }
+}
+
+@Composable
+private fun EmojiFallback(emoji: String, modifier: Modifier) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Text(text = emoji, style = MaterialTheme.typography.titleLarge)
+    }
+}

--- a/android/app/src/main/java/com/example/android/ui/lists/GroceryListScreen.kt
+++ b/android/app/src/main/java/com/example/android/ui/lists/GroceryListScreen.kt
@@ -29,14 +29,13 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.example.android.data.local.GroceryListItemRecord
+import com.example.android.data.repository.GroceryProductSummary
 import com.example.android.ui.components.ProductImage
 import com.example.android.viewmodel.shopper.CatalogProduct
 import com.example.android.viewmodel.shopper.GroceryListItemUi
@@ -53,7 +52,6 @@ fun GroceryListScreen(
     modifier: Modifier = Modifier
 ) {
     val state = shopperViewModel.uiState
-    var selectedItem by remember { mutableStateOf<GroceryListItemUi?>(null) }
 
     Surface(modifier = modifier.fillMaxSize(), color = Color.White) {
         Column(
@@ -127,7 +125,7 @@ fun GroceryListScreen(
                     Column {
                         state.searchResults.forEach { product ->
                             SearchResultRow(product = product) {
-                                shopperViewModel.addProduct(product)
+                                shopperViewModel.showProductSheet(product.toProductSummary())
                             }
                         }
                     }
@@ -188,7 +186,7 @@ fun GroceryListScreen(
                     items(state.groceryList, key = { it.id }) { item ->
                         GroceryItemCard(
                             item = item,
-                            onOpen = { selectedItem = item },
+                            onOpen = { shopperViewModel.showItemSheet(item.toRecord()) },
                             onIncrement = { shopperViewModel.incrementItem(item.id) },
                             onDecrement = { shopperViewModel.decrementItem(item.id) }
                         )
@@ -197,42 +195,61 @@ fun GroceryListScreen(
             }
         }
 
-        selectedItem?.let { item ->
-            androidx.compose.material.AlertDialog(
-                onDismissRequest = { selectedItem = null },
-                title = { Text(item.name) },
-                text = {
-                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                        Text("Store: ${item.store}")
-                        Text("Size: ${item.unitSize}")
-                        Text("Price: $${"%.2f".format(item.price)}")
-                        Text("Quantity: ${item.quantity}")
-                    }
+        state.productSheet?.let { summary ->
+            ProductDetailSheet(
+                summary = summary,
+                fullProduct = state.sheetProduct,
+                isLoadingFullProduct = state.isLoadingSheetProduct,
+                errorMessage = state.sheetProductError,
+                onAdd = { shopperViewModel.addFromProductSheet() },
+                onDismiss = { shopperViewModel.dismissProductSheet() }
+            )
+        }
+
+        state.itemSheet?.let { record ->
+            ItemDetailSheet(
+                item = record,
+                fullProduct = state.sheetProduct,
+                isLoadingFullProduct = state.isLoadingSheetProduct,
+                errorMessage = state.sheetProductError,
+                onIncrement = { shopperViewModel.incrementItem(record.id) },
+                onDecrement = { shopperViewModel.decrementItem(record.id) },
+                onRemove = {
+                    shopperViewModel.deleteItem(record.id)
+                    shopperViewModel.dismissItemSheet()
                 },
-                confirmButton = {
-                    Text(
-                        text = "Close",
-                        modifier = Modifier
-                            .clickable { selectedItem = null }
-                            .padding(12.dp),
-                        color = NeighborlyGreen
-                    )
-                },
-                dismissButton = {
-                    Text(
-                        text = "Delete",
-                        modifier = Modifier
-                            .clickable {
-                                shopperViewModel.deleteItem(item.id)
-                                selectedItem = null
-                            }
-                            .padding(12.dp),
-                        color = NeighborlyOrange
-                    )
-                }
+                onDismiss = { shopperViewModel.dismissItemSheet() }
             )
         }
     }
+}
+
+private fun CatalogProduct.toProductSummary(): GroceryProductSummary {
+    return GroceryProductSummary(
+        productId = productId,
+        upc = upc,
+        name = name,
+        brand = brand,
+        unitSize = unitSize,
+        bestPrice = price,
+        bestStoreName = store,
+        categoryEmoji = categoryEmoji,
+        imageUrl = imageUrl
+    )
+}
+
+private fun GroceryListItemUi.toRecord(): GroceryListItemRecord {
+    return GroceryListItemRecord(
+        id = id,
+        productId = productId,
+        upc = upc,
+        name = name,
+        unitSize = unitSize,
+        store = store,
+        price = price,
+        quantity = quantity,
+        dateAddedMillis = dateAddedMillis
+    )
 }
 
 @Composable

--- a/android/app/src/main/java/com/example/android/ui/lists/GroceryListScreen.kt
+++ b/android/app/src/main/java/com/example/android/ui/lists/GroceryListScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.example.android.ui.components.ProductImage
 import com.example.android.viewmodel.shopper.CatalogProduct
 import com.example.android.viewmodel.shopper.GroceryListItemUi
 import com.example.android.viewmodel.shopper.ShopperViewModel
@@ -244,7 +245,11 @@ private fun SearchResultRow(product: CatalogProduct, onAdd: () -> Unit) {
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Icon(Icons.Filled.AddCircle, contentDescription = null, tint = NeighborlyGreen)
+        ProductImage(
+            imageUrl = product.imageUrl,
+            contentDescription = product.name,
+            fallbackEmoji = product.categoryEmoji
+        )
         Column(modifier = Modifier.weight(1f)) {
             Text(product.name, style = MaterialTheme.typography.bodyLarge, color = Color(0xFF1A1A1A))
             Text(
@@ -280,6 +285,11 @@ private fun GroceryItemCard(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            // GroceryListItemRecord has no imageUrl/category yet; falls back to default emoji.
+            ProductImage(
+                imageUrl = null,
+                contentDescription = item.name
+            )
             Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(item.name, style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold))
                 Text(item.unitSize, style = MaterialTheme.typography.bodySmall, color = Color(0xFF777777))

--- a/android/app/src/main/java/com/example/android/ui/lists/GroceryListScreen.kt
+++ b/android/app/src/main/java/com/example/android/ui/lists/GroceryListScreen.kt
@@ -1,45 +1,68 @@
 package com.example.android.ui.lists
 
+import android.Manifest
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.RemoveCircle
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.android.data.local.GroceryListItemRecord
+import com.example.android.data.location.FusedLocationHelper
+import com.example.android.data.location.LocationHelper
+import com.example.android.data.location.UserCoordinates
 import com.example.android.data.repository.GroceryProductSummary
 import com.example.android.ui.components.ProductImage
+import com.example.android.viewmodel.route.RouteViewModel
 import com.example.android.viewmodel.shopper.CatalogProduct
 import com.example.android.viewmodel.shopper.GroceryListItemUi
 import com.example.android.viewmodel.shopper.ShopperViewModel
+import kotlinx.coroutines.launch
 
 private val NeighborlyBackground = Color(0xFFF7F3EC)
 private val NeighborlyGreen = Color(0xFF0C6A4A)
@@ -49,9 +72,91 @@ private val NeighborlyOrange = Color(0xFFE67E22)
 @Composable
 fun GroceryListScreen(
     shopperViewModel: ShopperViewModel,
+    routeViewModel: RouteViewModel,
+    onNavigateToRoute: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val state = shopperViewModel.uiState
+    val routeState = routeViewModel.uiState
+    val context = LocalContext.current
+    val locationHelper: LocationHelper = remember(context) { FusedLocationHelper(context) }
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val hasOptimizableItems = state.groceryList.any { !it.productId.isNullOrBlank() }
+    val isOptimizing = routeState.isLoading
+    // Tracks whether *this* screen kicked off the in-flight optimize. Without this
+    // flag the success `LaunchedEffect` would also fire whenever the user re-enters
+    // the Lists tab while an optimized route already lives in the shared VM,
+    // causing an immediate bounce back to the Route tab.
+    var awaitingOptimization by remember { mutableStateOf(false) }
+
+    fun launchOptimize(location: UserCoordinates?) {
+        awaitingOptimization = true
+        shopperViewModel.createRoute(routeViewModel, location)
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { results ->
+        val granted = results[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
+            results[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+        coroutineScope.launch {
+            val location = if (granted) locationHelper.requestLastKnownLocation() else null
+            launchOptimize(location)
+        }
+    }
+
+    fun onCreateRouteTapped() {
+        if (!hasOptimizableItems || isOptimizing) return
+        if (locationHelper.hasPermission()) {
+            coroutineScope.launch {
+                val location = locationHelper.requestLastKnownLocation()
+                launchOptimize(location)
+            }
+        } else {
+            permissionLauncher.launch(
+                arrayOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION
+                )
+            )
+        }
+    }
+
+    // When *our* optimize call resolves (route appears, no error, not loading)
+    // jump to the Route tab. Guarded by [awaitingOptimization] so revisiting the
+    // Lists tab with an existing route in memory doesn't re-trigger navigation.
+    LaunchedEffect(
+        awaitingOptimization,
+        routeState.optimizedRoute,
+        routeState.isLoading,
+        routeState.errorMessage
+    ) {
+        if (!awaitingOptimization) return@LaunchedEffect
+        if (routeState.isLoading) return@LaunchedEffect
+        if (routeState.errorMessage != null) {
+            awaitingOptimization = false
+            return@LaunchedEffect
+        }
+        if (routeState.optimizedRoute != null) {
+            awaitingOptimization = false
+            onNavigateToRoute()
+        }
+    }
+
+    LaunchedEffect(state.routeCreationError) {
+        val message = state.routeCreationError ?: return@LaunchedEffect
+        val result = snackbarHostState.showSnackbar(message)
+        if (result == SnackbarResult.Dismissed || result == SnackbarResult.ActionPerformed) {
+            shopperViewModel.clearRouteCreationError()
+        }
+    }
+
+    LaunchedEffect(routeState.errorMessage) {
+        val message = routeState.errorMessage ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(message)
+    }
 
     Surface(modifier = modifier.fillMaxSize(), color = Color.White) {
         Column(
@@ -192,7 +297,20 @@ fun GroceryListScreen(
                         )
                     }
                 }
+
+                if (state.searchQuery.isBlank()) {
+                    CreateRouteButton(
+                        enabled = hasOptimizableItems && !isOptimizing,
+                        isLoading = isOptimizing,
+                        onClick = ::onCreateRouteTapped
+                    )
+                }
             }
+
+            SnackbarHost(
+                hostState = snackbarHostState,
+                snackbar = { data -> Snackbar(snackbarData = data) }
+            )
         }
 
         state.productSheet?.let { summary ->
@@ -338,4 +456,52 @@ private fun GroceryItemCard(
 
 private fun Double?.formatPrice(): String {
     return this?.let { "$${"%.2f".format(it)}" } ?: "Price pending"
+}
+
+@Composable
+private fun CreateRouteButton(
+    enabled: Boolean,
+    isLoading: Boolean,
+    onClick: () -> Unit
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp),
+        shape = RoundedCornerShape(14.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = NeighborlyGreen,
+            contentColor = Color.White,
+            disabledContainerColor = NeighborlyGreen.copy(alpha = 0.4f),
+            disabledContentColor = Color.White
+        ),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 14.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            if (isLoading) {
+                CircularProgressIndicator(
+                    color = Color.White,
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(18.dp)
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.Send,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = if (isLoading) "Optimizing..." else "Create Route",
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold)
+            )
+        }
+    }
 }

--- a/android/app/src/main/java/com/example/android/ui/lists/ItemDetailSheet.kt
+++ b/android/app/src/main/java/com/example/android/ui/lists/ItemDetailSheet.kt
@@ -1,0 +1,213 @@
+package com.example.android.ui.lists
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.android.data.local.GroceryListItemRecord
+import com.example.android.data.model.Product
+import com.example.android.ui.components.ProductImage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ItemDetailSheet(
+    item: GroceryListItemRecord,
+    fullProduct: Product?,
+    isLoadingFullProduct: Boolean,
+    errorMessage: String?,
+    onIncrement: () -> Unit,
+    onDecrement: () -> Unit,
+    onRemove: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = SheetTheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
+                verticalAlignment = Alignment.Top
+            ) {
+                ProductImage(
+                    imageUrl = fullProduct?.imageUrl,
+                    contentDescription = item.name,
+                    fallbackEmoji = fullProduct?.productCategories?.emoji ?: "🛒",
+                    size = 96.dp,
+                    cornerRadius = 12.dp
+                )
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = item.name,
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                        color = SheetTheme.textPrimary
+                    )
+                    fullProduct?.brand?.takeIf { it.isNotBlank() }?.let { brand ->
+                        Text(
+                            text = brand,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = SheetTheme.textSecondary
+                        )
+                    }
+                    if (item.unitSize.isNotBlank()) {
+                        Text(
+                            text = item.unitSize,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = SheetTheme.textMuted
+                        )
+                    }
+                }
+            }
+
+            HorizontalDivider(color = SheetTheme.divider)
+
+            QuantityControls(
+                quantity = item.quantity,
+                onIncrement = onIncrement,
+                onDecrement = onDecrement
+            )
+
+            HorizontalDivider(color = SheetTheme.divider)
+
+            StorePricesSection(
+                fullProduct = fullProduct,
+                isLoading = isLoadingFullProduct,
+                errorMessage = errorMessage,
+                fallbackBestPrice = item.price.takeIf { it > 0.0 },
+                fallbackBestStoreName = item.store.takeIf { it.isNotBlank() }
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            TextButton(
+                onClick = onRemove,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Delete,
+                    contentDescription = null,
+                    tint = SheetTheme.orange
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(
+                    text = "Remove from list",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = SheetTheme.orange
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun QuantityControls(
+    quantity: Int,
+    onIncrement: () -> Unit,
+    onDecrement: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "Quantity",
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+            color = SheetTheme.textPrimary,
+            modifier = Modifier.weight(1f)
+        )
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(50))
+                .background(SheetTheme.cardBackground)
+                .padding(horizontal = 4.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            QuantityIconButton(
+                icon = Icons.Filled.Remove,
+                tint = SheetTheme.orange,
+                onClick = onDecrement,
+                contentDescription = "Decrease quantity"
+            )
+            Text(
+                text = quantity.toString(),
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                color = SheetTheme.textPrimary,
+                modifier = Modifier.padding(horizontal = 8.dp)
+            )
+            QuantityIconButton(
+                icon = Icons.Filled.Add,
+                tint = SheetTheme.green,
+                onClick = onIncrement,
+                contentDescription = "Increase quantity"
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuantityIconButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    tint: Color,
+    onClick: () -> Unit,
+    contentDescription: String
+) {
+    Box(
+        modifier = Modifier
+            .size(32.dp)
+            .clip(RoundedCornerShape(50))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = tint,
+            modifier = Modifier.size(20.dp)
+        )
+    }
+}

--- a/android/app/src/main/java/com/example/android/ui/lists/ProductDetailSheet.kt
+++ b/android/app/src/main/java/com/example/android/ui/lists/ProductDetailSheet.kt
@@ -1,0 +1,312 @@
+package com.example.android.ui.lists
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import com.example.android.data.model.Product
+import com.example.android.data.model.StoreProduct
+import com.example.android.data.repository.GroceryProductSummary
+import com.example.android.ui.components.ProductImage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProductDetailSheet(
+    summary: GroceryProductSummary,
+    fullProduct: Product?,
+    isLoadingFullProduct: Boolean,
+    errorMessage: String?,
+    onAdd: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = SheetTheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
+                verticalAlignment = Alignment.Top
+            ) {
+                ProductImage(
+                    imageUrl = summary.imageUrl,
+                    contentDescription = summary.name,
+                    fallbackEmoji = summary.categoryEmoji,
+                    size = 96.dp,
+                    cornerRadius = 12.dp
+                )
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = summary.name,
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                        color = SheetTheme.textPrimary
+                    )
+                    summary.brand?.takeIf { it.isNotBlank() }?.let { brand ->
+                        Text(
+                            text = brand,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = SheetTheme.textSecondary
+                        )
+                    }
+                    if (summary.unitSize.isNotBlank()) {
+                        Text(
+                            text = summary.unitSize,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = SheetTheme.textMuted
+                        )
+                    }
+                }
+            }
+
+            HorizontalDivider(color = SheetTheme.divider)
+
+            StorePricesSection(
+                fullProduct = fullProduct,
+                isLoading = isLoadingFullProduct,
+                errorMessage = errorMessage,
+                fallbackBestPrice = summary.bestPrice,
+                fallbackBestStoreName = summary.bestStoreName
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Button(
+                onClick = onAdd,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(14.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = SheetTheme.green,
+                    contentColor = Color.White
+                )
+            ) {
+                Icon(Icons.Filled.AddCircle, contentDescription = null)
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(
+                    text = "Add to Grocery List",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+internal fun StorePricesSection(
+    fullProduct: Product?,
+    isLoading: Boolean,
+    errorMessage: String?,
+    fallbackBestPrice: Double?,
+    fallbackBestStoreName: String?
+) {
+    when {
+        fullProduct != null && fullProduct.storeProducts.isNotEmpty() -> {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                SectionHeader("PRICES BY STORE")
+                val sorted = fullProduct.storeProducts.sortedBy { it.salePrice ?: it.price }
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    sorted.forEach { sp ->
+                        StoreProductRow(sp)
+                    }
+                }
+            }
+        }
+        isLoading -> {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                    color = SheetTheme.green
+                )
+                Text(
+                    text = "Loading store prices...",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = SheetTheme.textMuted
+                )
+            }
+        }
+        errorMessage != null -> {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = errorMessage,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+                FallbackPriceRow(fallbackBestPrice, fallbackBestStoreName)
+            }
+        }
+        else -> {
+            FallbackPriceRow(fallbackBestPrice, fallbackBestStoreName)
+        }
+    }
+}
+
+@Composable
+private fun FallbackPriceRow(bestPrice: Double?, bestStoreName: String?) {
+    if (bestPrice == null && bestStoreName.isNullOrBlank()) return
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        SectionHeader("BEST PRICE")
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(SheetTheme.cardBackground)
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(SheetTheme.green)
+            )
+            Text(
+                text = bestStoreName?.takeIf { it.isNotBlank() } ?: "Last known price",
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                color = SheetTheme.textPrimary,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = bestPrice?.let { formatCurrency(it) } ?: "—",
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                color = SheetTheme.green
+            )
+        }
+    }
+}
+
+@Composable
+private fun StoreProductRow(sp: StoreProduct) {
+    val effectivePrice = sp.salePrice ?: sp.price
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(SheetTheme.cardBackground)
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(SheetTheme.green)
+        )
+        Text(
+            text = sp.stores.name.ifBlank { sp.stores.chain ?: "Unknown" },
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+            color = SheetTheme.textPrimary
+        )
+        if (!sp.inStock) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(50))
+                    .background(SheetTheme.background)
+                    .padding(horizontal = 6.dp, vertical = 2.dp)
+            ) {
+                Text(
+                    text = "out of stock",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = SheetTheme.outOfStock
+                )
+            }
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Column(horizontalAlignment = Alignment.End) {
+            if (sp.salePrice != null) {
+                Text(
+                    text = formatCurrency(effectivePrice),
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = SheetTheme.green
+                )
+                Text(
+                    text = formatCurrency(sp.price),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = SheetTheme.textMuted,
+                    textDecoration = TextDecoration.LineThrough
+                )
+            } else {
+                Text(
+                    text = formatCurrency(sp.price),
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = SheetTheme.green
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun SectionHeader(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium.copy(
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = androidx.compose.ui.unit.TextUnit(0.5f, androidx.compose.ui.unit.TextUnitType.Sp)
+        ),
+        color = SheetTheme.textMuted
+    )
+}
+
+internal fun formatCurrency(value: Double): String = "$${"%.2f".format(value)}"
+
+internal object SheetTheme {
+    val background = Color(0xFFF7F3EC)
+    val cardBackground = Color(0xFFFFFFFF)
+    val green = Color(0xFF0C6A4A)
+    val orange = Color(0xFFE67E22)
+    val textPrimary = Color(0xFF1A1A1A)
+    val textSecondary = Color(0xFF3F5A50)
+    val textMuted = Color(0xFF6B7B73)
+    val divider = Color(0xFFE5E0D6)
+    val outOfStock = Color(0xB3D32F2F)
+}

--- a/android/app/src/main/java/com/example/android/ui/route/MapboxRouteMap.kt
+++ b/android/app/src/main/java/com/example/android/ui/route/MapboxRouteMap.kt
@@ -6,10 +6,16 @@ import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.Typeface
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -48,6 +55,7 @@ import com.mapbox.maps.viewannotation.viewAnnotationOptions
 private val PolylineGreen = Color(0xFF1FA86E)
 private val BadgeOrange = Color(0xFFE67E22)
 private val BadgeOrangeSoft = Color(0xFFFFF3E0)
+private val NeighborlyGreen = Color(0xFF0C6A4A)
 
 /**
  * Compose wrapper around the Mapbox Maps SDK matching the iOS
@@ -62,6 +70,8 @@ private val BadgeOrangeSoft = Color(0xFFFFF3E0)
  *     legible at any zoom level and reuses Compose typography.
  *   - Camera fit to bounds of [user, stops] with 40dp padding via the
  *     `MapboxMap.cameraForCoordinates` helper, animated with `flyTo`.
+ *   - Tapping a pin zooms to that single stop; an "All stops" pill in the
+ *     top-end corner returns to the fit-all viewport (mirrors iOS behavior).
  */
 @Composable
 fun MapboxRouteMap(
@@ -72,6 +82,8 @@ fun MapboxRouteMap(
 ) {
     val viewportState = rememberMapViewportState()
     var directions by remember { mutableStateOf<DirectionsResult?>(null) }
+    // null = fit all stops; non-null = zoomed to a single tapped pin's index
+    var focusedStopIndex by remember(stops) { mutableStateOf<Int?>(null) }
 
     val pinPoints = remember(stops) {
         stops.mapNotNull { stop ->
@@ -112,78 +124,145 @@ fun MapboxRouteMap(
         pinBitmaps.mapValues { (_, bmp) -> IconImage(bmp) }
     }
 
-    MapboxMap(
-        modifier = modifier,
-        mapViewportState = viewportState,
-        style = { MapStyle(style = "mapbox://styles/mapbox/streets-v12") }
-    ) {
-        // Enable the user-location puck and recompute camera bounds once the
-        // map view exists.
-        MapEffect(stops, userLocation) { mapView ->
-            mapView.location.updateSettings {
-                enabled = true
-                locationPuck = createDefault2DPuck(withBearing = true)
-                puckBearingEnabled = true
+    Box(modifier = modifier) {
+        MapboxMap(
+            modifier = Modifier.matchParentSize(),
+            mapViewportState = viewportState,
+            style = { MapStyle(style = "mapbox://styles/mapbox/streets-v12") }
+        ) {
+            // Enable the user-location puck and recompute camera bounds once the
+            // map view exists. Recomputes when `focusedStopIndex` flips so a
+            // pin tap (or "All stops" reset) animates the camera.
+            MapEffect(stops, userLocation, focusedStopIndex) { mapView ->
+                mapView.location.updateSettings {
+                    enabled = true
+                    locationPuck = createDefault2DPuck(withBearing = true)
+                    puckBearingEnabled = true
+                }
+
+                val focused = focusedStopIndex
+                if (focused != null) {
+                    val pin = pinPoints.getOrNull(focused)
+                    if (pin != null) {
+                        val (_, lat, lng) = pin
+                        val targetCamera = CameraOptions.Builder()
+                            .center(Point.fromLngLat(lng, lat))
+                            .zoom(15.0)
+                            .build()
+                        viewportState.flyTo(targetCamera)
+                        return@MapEffect
+                    }
+                }
+
+                val coords = buildList<Point> {
+                    userLocation?.let { add(Point.fromLngLat(it.longitude, it.latitude)) }
+                    pinPoints.forEach { (_, lat, lng) -> add(Point.fromLngLat(lng, lat)) }
+                }
+                if (coords.isEmpty()) return@MapEffect
+
+                val targetCamera = if (coords.size == 1) {
+                    CameraOptions.Builder()
+                        .center(coords.first())
+                        .zoom(14.0)
+                        .build()
+                } else {
+                    // v11 non-deprecated overload: takes a CameraOptions anchor
+                    // alongside coordinates / padding. Pass an empty anchor so
+                    // Mapbox computes both center and zoom from the bounds.
+                    mapView.mapboxMap.cameraForCoordinates(
+                        coords,
+                        CameraOptions.Builder().build(),
+                        EdgeInsets(40.0, 40.0, 40.0, 40.0),
+                        null,
+                        null
+                    )
+                }
+                viewportState.flyTo(targetCamera)
             }
 
-            val coords = buildList<Point> {
-                userLocation?.let { add(Point.fromLngLat(it.longitude, it.latitude)) }
-                pinPoints.forEach { (_, lat, lng) -> add(Point.fromLngLat(lng, lat)) }
-            }
-            if (coords.isEmpty()) return@MapEffect
-
-            val targetCamera = if (coords.size == 1) {
-                CameraOptions.Builder()
-                    .center(coords.first())
-                    .zoom(14.0)
-                    .build()
-            } else {
-                mapView.mapboxMap.cameraForCoordinates(
-                    coords,
-                    EdgeInsets(40.0, 40.0, 40.0, 40.0),
-                    null,
-                    null
-                )
-            }
-            viewportState.flyTo(targetCamera)
-        }
-
-        // Walking polyline (real or straight-line fallback).
-        if (polylinePoints.size >= 2) {
-            PolylineAnnotation(points = polylinePoints) {
-                lineColor = PolylineGreen
-                lineWidth = 4.0
-                lineOpacity = 0.8
-            }
-        }
-
-        // Numbered pins.
-        pinPoints.forEachIndexed { index, (_, lat, lng) ->
-            val displayNumber = index + 1
-            val point = Point.fromLngLat(lng, lat)
-            val icon = pinIcons[displayNumber] ?: return@forEachIndexed
-
-            PointAnnotation(point = point) {
-                iconImage = icon
-                iconAnchor = IconAnchor.BOTTOM
+            // Walking polyline (real or straight-line fallback). Always shown
+            // regardless of focus state.
+            if (polylinePoints.size >= 2) {
+                PolylineAnnotation(points = polylinePoints) {
+                    lineColor = PolylineGreen
+                    lineWidth = 4.0
+                    lineOpacity = 0.8
+                }
             }
 
-            // Per-leg ETA badge: walking duration from the previous waypoint
-            // (user when present, otherwise previous stop).
-            val legIndex = if (userLocation != null) index else index - 1
-            val durationSeconds = directions?.legs?.getOrNull(legIndex)?.durationSeconds
-            if (durationSeconds != null) {
-                val minutes = maxOf(1, (durationSeconds / 60.0).toInt())
-                ViewAnnotation(
-                    options = viewAnnotationOptions {
-                        geometry(point)
-                        allowOverlap(true)
+            // Numbered pins. Per-pin onClick captures the tapped index so the
+            // camera can fly to that single stop.
+            pinPoints.forEachIndexed { index, (_, lat, lng) ->
+                val displayNumber = index + 1
+                val point = Point.fromLngLat(lng, lat)
+                val icon = pinIcons[displayNumber] ?: return@forEachIndexed
+
+                PointAnnotation(
+                    point = point,
+                    onClick = {
+                        focusedStopIndex = index
+                        // Returning true marks the click handled and prevents
+                        // any further click propagation on the map.
+                        true
                     }
                 ) {
-                    EtaBadge(minutes = minutes)
+                    iconImage = icon
+                    iconAnchor = IconAnchor.BOTTOM
+                }
+
+                // Per-leg ETA badge: walking duration from the previous waypoint
+                // (user when present, otherwise previous stop). Always shown.
+                val legIndex = if (userLocation != null) index else index - 1
+                val durationSeconds = directions?.legs?.getOrNull(legIndex)?.durationSeconds
+                if (durationSeconds != null) {
+                    val minutes = maxOf(1, (durationSeconds / 60.0).toInt())
+                    ViewAnnotation(
+                        options = viewAnnotationOptions {
+                            geometry(point)
+                            allowOverlap(true)
+                        }
+                    ) {
+                        EtaBadge(minutes = minutes)
+                    }
                 }
             }
         }
+
+        // "All stops" reset pill, top-end corner. Only visible when zoomed
+        // to a single pin. Mirrors iOS `MapboxRouteMap.swift` lines 93-110.
+        if (focusedStopIndex != null) {
+            AllStopsPill(
+                onClick = { focusedStopIndex = null },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun AllStopsPill(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(50))
+            .background(NeighborlyGreen)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.wrapContentSize()
+        )
+        Text(
+            text = "All stops",
+            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+            color = Color.White
+        )
     }
 }
 

--- a/android/app/src/main/java/com/example/android/ui/route/MapboxRouteMap.kt
+++ b/android/app/src/main/java/com/example/android/ui/route/MapboxRouteMap.kt
@@ -1,0 +1,255 @@
+package com.example.android.ui.route
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.Typeface
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.android.data.location.UserCoordinates
+import com.example.android.data.maps.DirectionsResult
+import com.example.android.data.maps.KtorMapboxDirectionsService
+import com.example.android.data.maps.MapboxDirectionsService
+import com.example.android.viewmodel.route.OptimizedRouteStop
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.extension.compose.MapEffect
+import com.mapbox.maps.extension.compose.MapboxMap
+import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
+import com.mapbox.maps.extension.compose.annotation.IconImage
+import com.mapbox.maps.extension.compose.annotation.ViewAnnotation
+import com.mapbox.maps.extension.compose.annotation.generated.PointAnnotation
+import com.mapbox.maps.extension.compose.annotation.generated.PolylineAnnotation
+import com.mapbox.maps.extension.compose.style.MapStyle
+import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
+import com.mapbox.maps.plugin.locationcomponent.createDefault2DPuck
+import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.maps.viewannotation.geometry
+import com.mapbox.maps.viewannotation.viewAnnotationOptions
+
+private val PolylineGreen = Color(0xFF1FA86E)
+private val BadgeOrange = Color(0xFFE67E22)
+private val BadgeOrangeSoft = Color(0xFFFFF3E0)
+
+/**
+ * Compose wrapper around the Mapbox Maps SDK matching the iOS
+ * `MapboxRouteMap.swift`:
+ *   - Numbered store pins (1..N) drawn as bitmaps with a green circle and
+ *     downward-pointing tail.
+ *   - User-location 2D puck with bearing.
+ *   - Walking polyline from the Mapbox Directions API (green, 0.8 opacity);
+ *     falls back to straight lines between stops if the API fails.
+ *   - Per-leg ETA badges ("X min") rendered as Compose [ViewAnnotation]s
+ *     above each destination pin. Choosing view annotations keeps the badge
+ *     legible at any zoom level and reuses Compose typography.
+ *   - Camera fit to bounds of [user, stops] with 40dp padding via the
+ *     `MapboxMap.cameraForCoordinates` helper, animated with `flyTo`.
+ */
+@Composable
+fun MapboxRouteMap(
+    stops: List<OptimizedRouteStop>,
+    userLocation: UserCoordinates?,
+    modifier: Modifier = Modifier,
+    directionsService: MapboxDirectionsService = remember { KtorMapboxDirectionsService() }
+) {
+    val viewportState = rememberMapViewportState()
+    var directions by remember { mutableStateOf<DirectionsResult?>(null) }
+
+    val pinPoints = remember(stops) {
+        stops.mapNotNull { stop ->
+            val lat = stop.latitude
+            val lng = stop.longitude
+            if (lat != null && lng != null) Triple(stop, lat, lng) else null
+        }
+    }
+
+    // Fetch directions whenever stops or user location change. On failure we
+    // leave `directions = null` and the polyline below falls back to straight
+    // lines between stops. Mirrors iOS `fetchRoute()`.
+    LaunchedEffect(stops, userLocation) {
+        directions = null
+        val waypoints = buildList<Pair<Double, Double>> {
+            userLocation?.let { add(it.longitude to it.latitude) }
+            pinPoints.forEach { (_, lat, lng) -> add(lng to lat) }
+        }
+        if (waypoints.size >= 2) {
+            directionsService.walkingRoute(waypoints)
+                .onSuccess { directions = it }
+        }
+    }
+
+    val polylinePoints: List<Point> = remember(directions, pinPoints, userLocation) {
+        directions?.coordinates?.map { (lat, lng) -> Point.fromLngLat(lng, lat) }
+            ?: buildList {
+                userLocation?.let { add(Point.fromLngLat(it.longitude, it.latitude)) }
+                pinPoints.forEach { (_, lat, lng) -> add(Point.fromLngLat(lng, lat)) }
+            }
+    }
+
+    // Pre-render each numbered pin bitmap once per stop count change.
+    val pinBitmaps: Map<Int, Bitmap> = remember(pinPoints.size) {
+        (1..pinPoints.size).associateWith { renderPinBitmap(it) }
+    }
+    val pinIcons: Map<Int, IconImage> = remember(pinBitmaps) {
+        pinBitmaps.mapValues { (_, bmp) -> IconImage(bmp) }
+    }
+
+    MapboxMap(
+        modifier = modifier,
+        mapViewportState = viewportState,
+        style = { MapStyle(style = "mapbox://styles/mapbox/streets-v12") }
+    ) {
+        // Enable the user-location puck and recompute camera bounds once the
+        // map view exists.
+        MapEffect(stops, userLocation) { mapView ->
+            mapView.location.updateSettings {
+                enabled = true
+                locationPuck = createDefault2DPuck(withBearing = true)
+                puckBearingEnabled = true
+            }
+
+            val coords = buildList<Point> {
+                userLocation?.let { add(Point.fromLngLat(it.longitude, it.latitude)) }
+                pinPoints.forEach { (_, lat, lng) -> add(Point.fromLngLat(lng, lat)) }
+            }
+            if (coords.isEmpty()) return@MapEffect
+
+            val targetCamera = if (coords.size == 1) {
+                CameraOptions.Builder()
+                    .center(coords.first())
+                    .zoom(14.0)
+                    .build()
+            } else {
+                mapView.mapboxMap.cameraForCoordinates(
+                    coords,
+                    EdgeInsets(40.0, 40.0, 40.0, 40.0),
+                    null,
+                    null
+                )
+            }
+            viewportState.flyTo(targetCamera)
+        }
+
+        // Walking polyline (real or straight-line fallback).
+        if (polylinePoints.size >= 2) {
+            PolylineAnnotation(points = polylinePoints) {
+                lineColor = PolylineGreen
+                lineWidth = 4.0
+                lineOpacity = 0.8
+            }
+        }
+
+        // Numbered pins.
+        pinPoints.forEachIndexed { index, (_, lat, lng) ->
+            val displayNumber = index + 1
+            val point = Point.fromLngLat(lng, lat)
+            val icon = pinIcons[displayNumber] ?: return@forEachIndexed
+
+            PointAnnotation(point = point) {
+                iconImage = icon
+                iconAnchor = IconAnchor.BOTTOM
+            }
+
+            // Per-leg ETA badge: walking duration from the previous waypoint
+            // (user when present, otherwise previous stop).
+            val legIndex = if (userLocation != null) index else index - 1
+            val durationSeconds = directions?.legs?.getOrNull(legIndex)?.durationSeconds
+            if (durationSeconds != null) {
+                val minutes = maxOf(1, (durationSeconds / 60.0).toInt())
+                ViewAnnotation(
+                    options = viewAnnotationOptions {
+                        geometry(point)
+                        allowOverlap(true)
+                    }
+                ) {
+                    EtaBadge(minutes = minutes)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EtaBadge(minutes: Int) {
+    Box(
+        modifier = Modifier
+            .wrapContentSize()
+            .clip(RoundedCornerShape(50))
+            .background(BadgeOrangeSoft)
+            .padding(horizontal = 8.dp, vertical = 3.dp)
+    ) {
+        Text(
+            text = "$minutes min",
+            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+            color = BadgeOrange
+        )
+    }
+}
+
+/**
+ * Render a numbered pin bitmap matching the iOS `PinRenderer`: 30dp green
+ * circle + downward triangle tail with the index drawn in white.
+ */
+private fun renderPinBitmap(number: Int): Bitmap {
+    val width = 60
+    val pinDiameter = 30
+    val triHeight = 6
+    val totalHeight = pinDiameter + triHeight
+    val bitmap = Bitmap.createBitmap(width, totalHeight, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+
+    val greenColor = android.graphics.Color.argb(255, 12, 106, 74)
+
+    val circleX = (width - pinDiameter) / 2f
+    val circleY = 0f
+
+    val circlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = greenColor
+        setShadowLayer(2f, 0f, 1f, android.graphics.Color.argb(64, 0, 0, 0))
+    }
+    canvas.drawCircle(
+        circleX + pinDiameter / 2f,
+        circleY + pinDiameter / 2f,
+        pinDiameter / 2f,
+        circlePaint
+    )
+
+    val numberPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = android.graphics.Color.WHITE
+        textSize = 16f
+        textAlign = Paint.Align.CENTER
+        typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+    }
+    val textBaseline = circleY + pinDiameter / 2f - (numberPaint.descent() + numberPaint.ascent()) / 2f
+    canvas.drawText(number.toString(), circleX + pinDiameter / 2f, textBaseline, numberPaint)
+
+    val triTop = circleY + pinDiameter - 1f
+    val triPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = greenColor }
+    val triPath = Path().apply {
+        moveTo(width / 2f, triTop + triHeight)
+        lineTo(width / 2f - 5f, triTop)
+        lineTo(width / 2f + 5f, triTop)
+        close()
+    }
+    canvas.drawPath(triPath, triPaint)
+
+    return bitmap
+}

--- a/android/app/src/main/java/com/example/android/ui/route/RouteScreen.kt
+++ b/android/app/src/main/java/com/example/android/ui/route/RouteScreen.kt
@@ -123,7 +123,14 @@ private fun RouteContent(
         }
 
         item {
-            RouteMapPlaceholder(stops = route.stops)
+            MapboxRouteMap(
+                stops = route.stops,
+                userLocation = null,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(220.dp)
+                    .clip(RoundedCornerShape(24.dp))
+            )
         }
 
         items(route.stops, key = { stop -> "${stop.index}-${stop.storeId}-${stop.storeName}" }) { stop ->
@@ -196,49 +203,6 @@ private fun SummaryPill(text: String) {
             .padding(horizontal = 12.dp, vertical = 7.dp)
     ) {
         Text(text = text, style = MaterialTheme.typography.bodySmall, color = NeighborlyGreen)
-    }
-}
-
-@Composable
-private fun RouteMapPlaceholder(stops: List<OptimizedRouteStop>) {
-    val stopsWithCoordinates = stops.filter { it.latitude != null && it.longitude != null }
-
-    Card(
-        shape = RoundedCornerShape(24.dp),
-        colors = CardDefaults.cardColors(containerColor = Color(0xFFECF5EF)),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Icon(Icons.Outlined.Map, contentDescription = null, tint = NeighborlyGreen)
-                Text(
-                    "Map preview",
-                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                    color = NeighborlyInk
-                )
-            }
-            Text(
-                text = if (stopsWithCoordinates.isEmpty()) {
-                    "Route data is ready for map rendering once stop coordinates arrive from the API."
-                } else {
-                    "Showing ${stopsWithCoordinates.size} coordinate-backed stop pins. SDK polyline rendering can replace this bounded placeholder."
-                },
-                style = MaterialTheme.typography.bodyMedium,
-                color = Color(0xFF4F7E6B)
-            )
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                stopsWithCoordinates.forEach { stop ->
-                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                        StopNumber(index = stop.index)
-                        Text(
-                            text = "${stop.storeName}: ${"%.4f".format(stop.latitude)}, ${"%.4f".format(stop.longitude)}",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = NeighborlyInk
-                        )
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/android/app/src/main/java/com/example/android/ui/route/RouteScreen.kt
+++ b/android/app/src/main/java/com/example/android/ui/route/RouteScreen.kt
@@ -39,7 +39,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.example.android.data.model.categoryEmojiForSlug
 import com.example.android.data.repository.route.RouteSwapOption
+import com.example.android.ui.components.ProductImage
 import com.example.android.viewmodel.route.OptimizedRouteStop
 import com.example.android.viewmodel.route.RouteMissingItem
 import com.example.android.viewmodel.route.RoutePlan
@@ -280,7 +282,6 @@ private fun RouteStopCard(stop: OptimizedRouteStop, onSwapItem: (String?) -> Uni
 
 @Composable
 private fun RouteItemRow(item: RouteStopItem, onSwapItem: (String?) -> Unit) {
-    // TODO(S1.7): render ProductImage here once RouteStopItem carries imageUrl/categorySlug.
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -289,6 +290,13 @@ private fun RouteItemRow(item: RouteStopItem, onSwapItem: (String?) -> Unit) {
         horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
+        ProductImage(
+            imageUrl = item.imageUrl,
+            contentDescription = item.name,
+            fallbackEmoji = categoryEmojiForSlug(item.categorySlug),
+            size = 48.dp
+        )
+        Spacer(modifier = Modifier.size(2.dp))
         Icon(Icons.Filled.LocationOn, contentDescription = null, tint = NeighborlyGreen, modifier = Modifier.size(18.dp))
         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
             Text(item.name, style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold))

--- a/android/app/src/main/java/com/example/android/ui/route/RouteScreen.kt
+++ b/android/app/src/main/java/com/example/android/ui/route/RouteScreen.kt
@@ -288,6 +288,7 @@ private fun RouteStopCard(stop: OptimizedRouteStop, onSwapItem: (String?) -> Uni
 
 @Composable
 private fun RouteItemRow(item: RouteStopItem, onSwapItem: (String?) -> Unit) {
+    // TODO(S1.7): render ProductImage here once RouteStopItem carries imageUrl/categorySlug.
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/android/app/src/main/java/com/example/android/ui/route/RouteScreen.kt
+++ b/android/app/src/main/java/com/example/android/ui/route/RouteScreen.kt
@@ -45,6 +45,7 @@ import com.example.android.viewmodel.route.RouteMissingItem
 import com.example.android.viewmodel.route.RoutePlan
 import com.example.android.viewmodel.route.RouteStopItem
 import com.example.android.viewmodel.route.RouteViewModel
+import com.example.android.viewmodel.shopper.ShopperViewModel
 
 private val NeighborlyBackground = Color(0xFFF7F3EC)
 private val NeighborlyGreen = Color(0xFF0C6A4A)
@@ -55,6 +56,7 @@ private val NeighborlyInk = Color(0xFF1A1A1A)
 @Composable
 fun RouteScreen(
     routeViewModel: RouteViewModel,
+    shopperViewModel: ShopperViewModel,
     modifier: Modifier = Modifier
 ) {
     val state = routeViewModel.uiState
@@ -100,7 +102,33 @@ fun RouteScreen(
                     isLoading = state.isLoadingSwapOptions,
                     options = state.swapOptions,
                     errorMessage = state.swapErrorMessage,
-                    onDismiss = routeViewModel::dismissSwapAlternatives
+                    onDismiss = routeViewModel::dismissSwapAlternatives,
+                    onSelectOption = { option ->
+                        // The route's selected swap product id is the *current* product id of
+                        // the item being swapped. Resolve it back to the persisted grocery-list
+                        // record id so the repository knows which row to mutate. If the item
+                        // has no product id (e.g. legacy entries), there is nothing to swap.
+                        val currentProductId = state.selectedSwapProductId
+                        val currentItemId = shopperViewModel.findItemIdByProductId(currentProductId)
+                        if (currentItemId == null) {
+                            routeViewModel.dismissSwapAlternatives()
+                            return@SwapAlternativesDialog
+                        }
+                        val preferences = shopperViewModel.uiState.preferences
+                        val mode = preferences.priority.toBackendMode()
+                        val maxStops = preferences.maxStops.toInt().takeIf { it < 11 }
+                        val maxRadiusMiles = preferences.maxTravelDistanceMiles.toDouble()
+                            .takeIf { preferences.maxTravelDistanceMiles.toInt() < 11 }
+                        shopperViewModel.applySwap(currentItemId, option.productId) { newProductIds ->
+                            routeViewModel.setPendingProducts(newProductIds)
+                            routeViewModel.optimizePendingRoute(
+                                mode = mode,
+                                maxStops = maxStops,
+                                maxRadiusMiles = maxRadiusMiles,
+                            )
+                        }
+                        routeViewModel.dismissSwapAlternatives()
+                    }
                 )
             }
         }
@@ -378,7 +406,8 @@ private fun SwapAlternativesDialog(
     isLoading: Boolean,
     options: List<RouteSwapOption>,
     errorMessage: String?,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onSelectOption: (RouteSwapOption) -> Unit
 ) {
     androidx.compose.material.AlertDialog(
         onDismissRequest = onDismiss,
@@ -393,7 +422,13 @@ private fun SwapAlternativesDialog(
                     errorMessage != null -> Text(errorMessage, color = NeighborlyOrange)
                     options.isEmpty() -> Text("No alternatives returned for this product yet.")
                     else -> options.forEach { option ->
-                        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelectOption(option) }
+                                .padding(vertical = 6.dp),
+                            verticalArrangement = Arrangement.spacedBy(2.dp)
+                        ) {
                             Text(option.name, fontWeight = FontWeight.SemiBold)
                             Text(
                                 listOfNotNull(option.storeName, option.price.formatMoneyOrDash(), option.reason).joinToString(" • "),

--- a/android/app/src/main/java/com/example/android/viewmodel/route/RouteViewModel.kt
+++ b/android/app/src/main/java/com/example/android/viewmodel/route/RouteViewModel.kt
@@ -5,9 +5,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.android.data.repository.route.ApiRouteRepository
 import com.example.android.data.repository.route.RouteRepository
 import com.example.android.data.repository.route.RouteSwapOption
-import com.example.android.data.repository.route.UnavailableRouteRepository
 import kotlinx.coroutines.launch
 
 data class RoutePlan(
@@ -86,7 +86,7 @@ data class RouteUiState(
 }
 
 class RouteViewModel(
-    private val routeRepository: RouteRepository = UnavailableRouteRepository()
+    private val routeRepository: RouteRepository = ApiRouteRepository()
 ) : ViewModel() {
     var uiState by mutableStateOf(RouteUiState())
         private set

--- a/android/app/src/main/java/com/example/android/viewmodel/route/RouteViewModel.kt
+++ b/android/app/src/main/java/com/example/android/viewmodel/route/RouteViewModel.kt
@@ -91,9 +91,16 @@ class RouteViewModel(
     var uiState by mutableStateOf(RouteUiState())
         private set
 
-    fun createRoute(productIds: List<String>, userLat: Double? = null, userLng: Double? = null) {
+    fun createRoute(
+        productIds: List<String>,
+        userLat: Double? = null,
+        userLng: Double? = null,
+        mode: String? = null,
+        maxStops: Int? = null,
+        maxRadiusMiles: Double? = null
+    ) {
         setPendingProducts(productIds)
-        optimizePendingRoute(userLat, userLng)
+        optimizePendingRoute(userLat, userLng, mode, maxStops, maxRadiusMiles)
     }
 
     fun setPendingProducts(productIds: List<String>) {
@@ -109,7 +116,13 @@ class RouteViewModel(
         )
     }
 
-    fun optimizePendingRoute(userLat: Double? = null, userLng: Double? = null) {
+    fun optimizePendingRoute(
+        userLat: Double? = null,
+        userLng: Double? = null,
+        mode: String? = null,
+        maxStops: Int? = null,
+        maxRadiusMiles: Double? = null
+    ) {
         val productIds = uiState.pendingProductIds
         if (productIds.isEmpty()) {
             uiState = uiState.copy(
@@ -121,7 +134,14 @@ class RouteViewModel(
 
         uiState = uiState.copy(isLoading = true, errorMessage = null)
         viewModelScope.launch {
-            routeRepository.optimizeRoute(productIds, userLat, userLng)
+            routeRepository.optimizeRoute(
+                productIds = productIds,
+                userLat = userLat,
+                userLng = userLng,
+                mode = mode,
+                maxStops = maxStops,
+                maxRadiusMiles = maxRadiusMiles
+            )
                 .onSuccess { submitOptimizedRoute(it) }
                 .onFailure { failure ->
                     uiState = uiState.copy(

--- a/android/app/src/main/java/com/example/android/viewmodel/route/RouteViewModel.kt
+++ b/android/app/src/main/java/com/example/android/viewmodel/route/RouteViewModel.kt
@@ -62,7 +62,9 @@ data class RouteStopItem(
     val unitSize: String?,
     val price: Double?,
     val originalPrice: Double?,
-    val swapAvailable: Boolean = false
+    val swapAvailable: Boolean = false,
+    val imageUrl: String? = null,
+    val categorySlug: String? = null
 )
 
 data class RouteMissingItem(

--- a/android/app/src/main/java/com/example/android/viewmodel/shopper/ShopperViewModel.kt
+++ b/android/app/src/main/java/com/example/android/viewmodel/shopper/ShopperViewModel.kt
@@ -15,10 +15,13 @@ import com.example.android.data.local.SharedPreferencesGroceryListLocalDataSourc
 import com.example.android.data.model.Product
 import com.example.android.data.repository.GroceryListRepository
 import com.example.android.data.repository.GroceryProductSummary
+import com.example.android.data.repository.toGroceryProductSummary
 import com.example.android.data.repository.preferences.OptimizationPriority
 import com.example.android.data.repository.preferences.PreferenceRepository
 import com.example.android.data.repository.preferences.PreferenceState
 import com.example.android.data.repository.preferences.TransportMode
+import com.example.android.data.location.UserCoordinates
+import com.example.android.viewmodel.route.RouteViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -63,7 +66,8 @@ data class ShopperUiState(
     val itemSheet: GroceryListItemRecord? = null,
     val sheetProduct: Product? = null,
     val isLoadingSheetProduct: Boolean = false,
-    val sheetProductError: String? = null
+    val sheetProductError: String? = null,
+    val routeCreationError: String? = null
 ) {
     val filteredCatalog: List<CatalogProduct>
         get() = searchResults
@@ -307,6 +311,92 @@ class ShopperViewModel @JvmOverloads constructor(
         }
     }
 
+    /**
+     * Kicks off route optimization for the current grocery list. The screen layer
+     * is responsible for requesting location permission first; we just take an
+     * optional [userLocation] and forward it to the route view model along with
+     * the user's persisted preferences.
+     *
+     * Empty-product-ID lists set [ShopperUiState.routeCreationError] instead of
+     * hitting the API — mirrors iOS `optimizeRoute` (GroceryListView.swift:523-528).
+     *
+     * The slider sentinel `11` (max value) is interpreted as "unlimited" and
+     * sent to the backend as `null` for both `max_stops` and `max_radius_miles`,
+     * matching iOS `Priority` mapping in PreferencesView.swift.
+     */
+    fun createRoute(
+        routeViewModel: RouteViewModel,
+        userLocation: UserCoordinates?
+    ) {
+        val productIds = uiState.groceryList.mapNotNull { item ->
+            item.productId?.takeIf { it.isNotBlank() }
+        }
+        if (productIds.isEmpty()) {
+            uiState = uiState.copy(
+                routeCreationError = "Add at least one priced product before creating a route."
+            )
+            return
+        }
+
+        val preferences = uiState.preferences
+        val mode = preferences.priority.toBackendMode()
+        val maxStops = preferences.maxStops.toInt().takeIf { it < UNLIMITED_PREFERENCE_SLIDER_VALUE }
+        val maxRadiusMiles = preferences.maxTravelDistanceMiles.toDouble()
+            .takeIf { it < UNLIMITED_PREFERENCE_SLIDER_VALUE }
+
+        uiState = uiState.copy(routeCreationError = null)
+        routeViewModel.createRoute(
+            productIds = productIds,
+            userLat = userLocation?.latitude,
+            userLng = userLocation?.longitude,
+            mode = mode,
+            maxStops = maxStops,
+            maxRadiusMiles = maxRadiusMiles
+        )
+    }
+
+    fun clearRouteCreationError() {
+        if (uiState.routeCreationError != null) {
+            uiState = uiState.copy(routeCreationError = null)
+        }
+    }
+
+    fun findItemIdByProductId(productId: String?): String? {
+        if (productId.isNullOrBlank()) return null
+        return uiState.groceryList.firstOrNull { it.productId == productId }?.id
+    }
+
+    /**
+     * Apply a swap selected from the route's alternatives dialog. Fetches the full
+     * [Product] for [replacementProductId] so the persisted grocery-list record can
+     * carry the same field set as items added via search, then replaces the row
+     * identified by [currentItemId] in the local list. On success [onComplete] is
+     * invoked with the updated list of product IDs so the route can be re-optimized.
+     */
+    fun applySwap(
+        currentItemId: String,
+        replacementProductId: String,
+        onComplete: (productIds: List<String>) -> Unit
+    ) {
+        viewModelScope.launch {
+            api.getProduct(replacementProductId)
+                .onSuccess { product ->
+                    val summary = product.toGroceryProductSummary()
+                    val updatedItems = groceryListRepository.replaceProduct(currentItemId, summary)
+                    uiState = uiState.copy(
+                        groceryList = updatedItems.toUiItems(),
+                        refreshError = null
+                    )
+                    onComplete(updatedItems.mapNotNull { it.productId })
+                }
+                .onFailure { error ->
+                    uiState = uiState.copy(
+                        refreshError = error.message ?: "Unable to apply swap."
+                    )
+                }
+        }
+    }
+
     fun updatePriority(priority: OptimizationPriority) {
         updatePreferences { it.copy(priority = priority) }
     }
@@ -437,5 +527,9 @@ class ShopperViewModel @JvmOverloads constructor(
     private companion object {
         const val MIN_SEARCH_QUERY_LENGTH = 2
         const val SEARCH_DEBOUNCE_MILLIS = 300L
+        // Preference sliders (`maxStops`, `maxTravelDistanceMiles`) range 1..11; the
+        // top notch represents "unlimited" — drop the cap when sending to the
+        // backend. Mirrors iOS PreferencesView.swift sentinel handling.
+        const val UNLIMITED_PREFERENCE_SLIDER_VALUE = 11
     }
 }

--- a/android/app/src/main/java/com/example/android/viewmodel/shopper/ShopperViewModel.kt
+++ b/android/app/src/main/java/com/example/android/viewmodel/shopper/ShopperViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.android.data.connectivity.NetworkMonitor
 import com.example.android.data.local.GroceryListItemRecord
 import com.example.android.data.local.preferences.SharedPreferencesPreferenceRepository
 import com.example.android.data.local.SharedPreferencesGroceryListLocalDataSource
@@ -18,6 +19,7 @@ import com.example.android.data.repository.preferences.TransportMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -66,7 +68,8 @@ class ShopperViewModel @JvmOverloads constructor(
     ),
     private val preferenceRepository: PreferenceRepository = SharedPreferencesPreferenceRepository(
         application.applicationContext
-    )
+    ),
+    private val networkMonitor: NetworkMonitor? = null
 ) : AndroidViewModel(application) {
     var uiState by mutableStateOf(ShopperUiState())
         private set
@@ -82,6 +85,23 @@ class ShopperViewModel @JvmOverloads constructor(
             uiState = uiState.copy(preferences = persistedPreferences)
         }
         refreshPrices()
+        observeConnectivity()
+    }
+
+    private fun observeConnectivity() {
+        val monitor = networkMonitor ?: return
+        viewModelScope.launch {
+            // Skip the very first emission — `init` already kicks off `refreshPrices()`.
+            // Only `false -> true` transitions after that should trigger a refresh, mirroring
+            // iOS `NetworkMonitor.didReconnect` (GroceryListView.swift:9-36).
+            var previous: Boolean? = null
+            monitor.isOnline.collect { current ->
+                if (previous == false && current) {
+                    refreshPrices()
+                }
+                previous = current
+            }
+        }
     }
 
     fun updateSearchQuery(value: String) {

--- a/android/app/src/main/java/com/example/android/viewmodel/shopper/ShopperViewModel.kt
+++ b/android/app/src/main/java/com/example/android/viewmodel/shopper/ShopperViewModel.kt
@@ -6,10 +6,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.android.data.api.KtorNeighborlyApi
+import com.example.android.data.api.NeighborlyApi
 import com.example.android.data.connectivity.NetworkMonitor
 import com.example.android.data.local.GroceryListItemRecord
 import com.example.android.data.local.preferences.SharedPreferencesPreferenceRepository
 import com.example.android.data.local.SharedPreferencesGroceryListLocalDataSource
+import com.example.android.data.model.Product
 import com.example.android.data.repository.GroceryListRepository
 import com.example.android.data.repository.GroceryProductSummary
 import com.example.android.data.repository.preferences.OptimizationPriority
@@ -55,7 +58,12 @@ data class ShopperUiState(
     val searchError: String? = null,
     val isRefreshingPrices: Boolean = false,
     val refreshError: String? = null,
-    val preferences: PreferenceState = PreferenceState()
+    val preferences: PreferenceState = PreferenceState(),
+    val productSheet: GroceryProductSummary? = null,
+    val itemSheet: GroceryListItemRecord? = null,
+    val sheetProduct: Product? = null,
+    val isLoadingSheetProduct: Boolean = false,
+    val sheetProductError: String? = null
 ) {
     val filteredCatalog: List<CatalogProduct>
         get() = searchResults
@@ -69,12 +77,14 @@ class ShopperViewModel @JvmOverloads constructor(
     private val preferenceRepository: PreferenceRepository = SharedPreferencesPreferenceRepository(
         application.applicationContext
     ),
-    private val networkMonitor: NetworkMonitor? = null
+    private val networkMonitor: NetworkMonitor? = null,
+    private val api: NeighborlyApi = KtorNeighborlyApi()
 ) : AndroidViewModel(application) {
     var uiState by mutableStateOf(ShopperUiState())
         private set
 
     private var searchJob: Job? = null
+    private var sheetProductJob: Job? = null
 
     init {
         uiState = uiState.copy(groceryList = groceryListRepository.loadItems().toUiItems())
@@ -160,15 +170,122 @@ class ShopperViewModel @JvmOverloads constructor(
     }
 
     fun incrementItem(id: String) {
-        uiState = uiState.copy(groceryList = groceryListRepository.incrementItem(id).toUiItems())
+        val updated = groceryListRepository.incrementItem(id)
+        uiState = uiState.copy(
+            groceryList = updated.toUiItems(),
+            itemSheet = uiState.itemSheet?.let { current ->
+                if (current.id == id) updated.firstOrNull { it.id == id } else current
+            }
+        )
     }
 
     fun decrementItem(id: String) {
-        uiState = uiState.copy(groceryList = groceryListRepository.decrementItem(id).toUiItems())
+        val updated = groceryListRepository.decrementItem(id)
+        val nextItemSheet = uiState.itemSheet?.let { current ->
+            if (current.id == id) updated.firstOrNull { it.id == id } else current
+        }
+        uiState = uiState.copy(
+            groceryList = updated.toUiItems(),
+            itemSheet = nextItemSheet
+        )
     }
 
     fun deleteItem(id: String) {
-        uiState = uiState.copy(groceryList = groceryListRepository.deleteItem(id).toUiItems())
+        val updated = groceryListRepository.deleteItem(id)
+        val nextItemSheet = uiState.itemSheet?.takeIf { it.id != id }
+        uiState = uiState.copy(
+            groceryList = updated.toUiItems(),
+            itemSheet = nextItemSheet
+        )
+    }
+
+    fun showProductSheet(summary: GroceryProductSummary) {
+        sheetProductJob?.cancel()
+        uiState = uiState.copy(
+            productSheet = summary,
+            itemSheet = null,
+            sheetProduct = null,
+            sheetProductError = null,
+            isLoadingSheetProduct = false
+        )
+        loadSheetProduct(summary.productId)
+    }
+
+    fun dismissProductSheet() {
+        sheetProductJob?.cancel()
+        uiState = uiState.copy(
+            productSheet = null,
+            sheetProduct = null,
+            isLoadingSheetProduct = false,
+            sheetProductError = null
+        )
+    }
+
+    fun showItemSheet(item: GroceryListItemRecord) {
+        sheetProductJob?.cancel()
+        uiState = uiState.copy(
+            itemSheet = item,
+            productSheet = null,
+            sheetProduct = null,
+            sheetProductError = null,
+            isLoadingSheetProduct = false
+        )
+        loadSheetProduct(item.productId)
+    }
+
+    fun dismissItemSheet() {
+        sheetProductJob?.cancel()
+        uiState = uiState.copy(
+            itemSheet = null,
+            sheetProduct = null,
+            isLoadingSheetProduct = false,
+            sheetProductError = null
+        )
+    }
+
+    fun addFromProductSheet() {
+        val summary = uiState.productSheet ?: return
+        val updatedItems = groceryListRepository.addOrIncrement(summary)
+        uiState = uiState.copy(
+            groceryList = updatedItems.toUiItems(),
+            searchQuery = "",
+            searchResults = emptyList(),
+            isSearchLoading = false,
+            searchError = null,
+            productSheet = null,
+            sheetProduct = null,
+            isLoadingSheetProduct = false,
+            sheetProductError = null
+        )
+    }
+
+    private fun loadSheetProduct(productId: String?) {
+        if (productId.isNullOrBlank()) return
+        uiState = uiState.copy(isLoadingSheetProduct = true, sheetProductError = null)
+        sheetProductJob = viewModelScope.launch {
+            api.getProduct(productId)
+                .onSuccess { product ->
+                    if (uiState.productSheet?.productId == productId ||
+                        uiState.itemSheet?.productId == productId
+                    ) {
+                        uiState = uiState.copy(
+                            sheetProduct = product,
+                            isLoadingSheetProduct = false,
+                            sheetProductError = null
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    if (uiState.productSheet?.productId == productId ||
+                        uiState.itemSheet?.productId == productId
+                    ) {
+                        uiState = uiState.copy(
+                            isLoadingSheetProduct = false,
+                            sheetProductError = error.message ?: "Unable to load product details."
+                        )
+                    }
+                }
+        }
     }
 
     fun refreshPrices() {

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/android/app/src/test/java/com/example/android/data/connectivity/NetworkMonitorTest.kt
+++ b/android/app/src/test/java/com/example/android/data/connectivity/NetworkMonitorTest.kt
@@ -1,0 +1,146 @@
+package com.example.android.data.connectivity
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Verifies the reconnect-detection logic that `ShopperViewModel.observeConnectivity`
+ * relies on (skip-first + false→true transition emits).
+ *
+ * The real `ConnectivityManagerNetworkMonitor` is not unit-testable on the JVM
+ * (it touches Android `ConnectivityManager`), so we assert that:
+ *   1. `distinctUntilChanged` filters consecutive duplicates from a fake monitor.
+ *   2. A small `ReconnectDetector` (mirroring the inline logic in
+ *      `ShopperViewModel.observeConnectivity`) only emits `true` on
+ *      `false -> true` transitions, skipping the very first emission.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NetworkMonitorTest {
+
+    /**
+     * Fake monitor whose `isOnline` flow we drive from a `MutableStateFlow`.
+     * Wraps the state flow in `distinctUntilChanged` to mirror the production
+     * implementation's terminal operator.
+     */
+    private class FakeNetworkMonitor(initial: Boolean) : NetworkMonitor {
+        private val state = MutableStateFlow(initial)
+        // StateFlow already de-dupes consecutive duplicates; no need to wrap in
+        // `distinctUntilChanged` (the Kotlin compiler treats that as an error
+        // since 1.9 — see "Operator Fusion" in StateFlow docs).
+        override val isOnline: Flow<Boolean> = state
+
+        fun emit(value: Boolean) {
+            state.value = value
+        }
+    }
+
+    /**
+     * Mirrors `ShopperViewModel.observeConnectivity`: starts with `previous = null`,
+     * collects the source flow, and emits `Unit` (treated as a "reconnect" pulse)
+     * only when `previous == false && current == true`.
+     */
+    private fun reconnectPulses(source: Flow<Boolean>): Flow<Unit> = flow {
+        var previous: Boolean? = null
+        source.collect { current ->
+            if (previous == false && current) {
+                emit(Unit)
+            }
+            previous = current
+        }
+    }
+
+    @Test
+    fun `distinctUntilChanged filters consecutive duplicates from fake monitor`() = runTest {
+        // Build a finite source so toList terminates.
+        val source: Flow<Boolean> = flow {
+            emit(true)
+            emit(true)
+            emit(false)
+            emit(false)
+            emit(true)
+        }.distinctUntilChanged()
+
+        val collected = source.toList()
+        assertEquals(listOf(true, false, true), collected)
+    }
+
+    @Test
+    fun `initial true alone does not emit a reconnect`() = runTest {
+        val source = flow { emit(true) }
+        val pulses = reconnectPulses(source).toList()
+        assertEquals(0, pulses.size)
+    }
+
+    @Test
+    fun `initial false then true emits one reconnect`() = runTest {
+        val source = flow {
+            emit(false)
+            emit(true)
+        }
+        val pulses = reconnectPulses(source).toList()
+        assertEquals(1, pulses.size)
+    }
+
+    @Test
+    fun `true to false to true emits one reconnect`() = runTest {
+        val source = flow {
+            emit(true)
+            emit(false)
+            emit(true)
+        }
+        val pulses = reconnectPulses(source).toList()
+        assertEquals(1, pulses.size)
+    }
+
+    @Test
+    fun `consecutive true emissions do not trigger a reconnect`() = runTest {
+        // After distinctUntilChanged duplicates would be filtered; but even
+        // without it, the detector requires a `false` in-between.
+        val source = flow {
+            emit(true)
+            emit(true)
+            emit(true)
+        }
+        val pulses = reconnectPulses(source).toList()
+        assertEquals(0, pulses.size)
+    }
+
+    @Test
+    fun `multiple reconnect cycles each emit a pulse`() = runTest {
+        val source = flow {
+            emit(false)
+            emit(true)   // pulse 1
+            emit(false)
+            emit(true)   // pulse 2
+        }
+        val pulses = reconnectPulses(source).toList()
+        assertEquals(2, pulses.size)
+    }
+
+    @Test
+    fun `fake NetworkMonitor wires through to the detector`() = runTest {
+        val monitor = FakeNetworkMonitor(initial = true)
+        // Drive the monitor through a transition while collecting.
+        // Because we need a finite stream, use a flow that pulls a few values
+        // off the monitor by combining with explicit state updates.
+        val transitions = flow {
+            emit(true)   // initial
+            emit(false)  // dropped
+            emit(true)   // reconnect
+        }.distinctUntilChanged()
+
+        val pulses = reconnectPulses(transitions).toList()
+        assertEquals(1, pulses.size)
+
+        // sanity check: the fake responds to mutation through the public surface.
+        monitor.emit(false)
+        monitor.emit(true)
+    }
+}

--- a/android/app/src/test/java/com/example/android/data/model/RouteModelsParsingTest.kt
+++ b/android/app/src/test/java/com/example/android/data/model/RouteModelsParsingTest.kt
@@ -1,0 +1,129 @@
+package com.example.android.data.model
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks in the JSON-decoding behavior for `/routes/optimize` responses.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+class RouteModelsParsingTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `parses happy path response with stops and missing items`() {
+        val payload = """
+            {
+              "total_cost": 12.34,
+              "stops": [
+                {
+                  "store": {
+                    "id": "store-1",
+                    "name": "Trader Joe's",
+                    "address": "123 Main St",
+                    "lat": 37.0,
+                    "lng": -122.0
+                  },
+                  "items": [
+                    {
+                      "product_id": "prod-1",
+                      "name": "Milk",
+                      "unit_size": "1 gal",
+                      "price": 3.99,
+                      "sale_price": 2.99
+                    }
+                  ],
+                  "subtotal": 2.99
+                }
+              ],
+              "items_not_found": ["weird-item"]
+            }
+        """.trimIndent()
+
+        val route = json.decodeFromString(OptimizedRoute.serializer(), payload)
+
+        assertEquals(12.34, route.totalCost, 0.0)
+        assertEquals(1, route.stops.size)
+        val stop = route.stops.single()
+        assertEquals("store-1", stop.store.id)
+        assertEquals("Trader Joe's", stop.store.name)
+        assertEquals("store-1", stop.id) // falls through to store.id
+        assertEquals(1, stop.items.size)
+        val item = stop.items.single()
+        assertEquals("prod-1", item.productId)
+        assertEquals("prod-1", item.id)
+        assertEquals(3.99, item.price, 0.0)
+        assertEquals(2.99, item.salePrice!!, 0.0)
+        assertEquals(listOf("weird-item"), route.itemsNotFound)
+    }
+
+    @Test
+    fun `parses no-route response with empty stops and unfound items`() {
+        val payload = """
+            {
+              "total_cost": 0.0,
+              "stops": [],
+              "items_not_found": ["banana", "cucumber"]
+            }
+        """.trimIndent()
+
+        val route = json.decodeFromString(OptimizedRoute.serializer(), payload)
+
+        assertTrue(route.stops.isEmpty())
+        assertEquals(listOf("banana", "cucumber"), route.itemsNotFound)
+        assertEquals(0.0, route.totalCost, 0.0)
+    }
+
+    @Test
+    fun `RouteStop id falls back to store name when store id is null`() {
+        val payload = """
+            {
+              "total_cost": 1.0,
+              "stops": [
+                {
+                  "store": { "name": "Corner Mart" },
+                  "items": [],
+                  "subtotal": 0.0
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val route = json.decodeFromString(OptimizedRoute.serializer(), payload)
+        val stop = route.stops.single()
+        assertNull(stop.store.id)
+        assertEquals("Corner Mart", stop.id)
+    }
+
+    @Test
+    fun `RouteItem id returns productId`() {
+        val item = RouteItem(
+            productId = "abc-123",
+            name = "Bread",
+            unitSize = "1 loaf",
+            price = 4.5
+        )
+        assertEquals("abc-123", item.id)
+    }
+
+    @Test
+    fun `defaults to empty itemsNotFound when omitted`() {
+        val payload = """
+            {
+              "total_cost": 5.0,
+              "stops": []
+            }
+        """.trimIndent()
+
+        val route = json.decodeFromString(OptimizedRoute.serializer(), payload)
+        assertTrue(route.itemsNotFound.isEmpty())
+    }
+}

--- a/android/app/src/test/java/com/example/android/data/model/RouteModelsTest.kt
+++ b/android/app/src/test/java/com/example/android/data/model/RouteModelsTest.kt
@@ -1,0 +1,89 @@
+package com.example.android.data.model
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks in the JSON contract emitted by `OptimizeRouteRequest`. Mirrors the
+ * `Json` config used by `KtorNeighborlyApi.defaultHttpClient` (`explicitNulls = false`).
+ */
+@OptIn(ExperimentalSerializationApi::class)
+class RouteModelsTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `serializes snake_case keys with all fields`() {
+        val request = OptimizeRouteRequest(
+            productIds = listOf("p1", "p2"),
+            userLat = 37.7749,
+            userLng = -122.4194,
+            mode = "cost",
+            maxStops = 5,
+            maxRadiusMiles = 3.0
+        )
+
+        val encoded = json.encodeToString(request)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        assertTrue("expected product_ids key", obj.containsKey("product_ids"))
+        val productIds = obj["product_ids"]
+        assertNotNull(productIds)
+        assertTrue("product_ids should be a JSON array", productIds is JsonArray)
+        val productIdValues = (productIds as JsonArray).map { it.jsonPrimitive.content }
+        assertEquals(listOf("p1", "p2"), productIdValues)
+
+        assertEquals(37.7749, obj["user_lat"]!!.jsonPrimitive.double, 0.0)
+        assertEquals(-122.4194, obj["user_lng"]!!.jsonPrimitive.double, 0.0)
+        assertEquals("cost", obj["mode"]!!.jsonPrimitive.content)
+        assertEquals(5, obj["max_stops"]!!.jsonPrimitive.int)
+        assertEquals(3.0, obj["max_radius_miles"]!!.jsonPrimitive.double, 0.0)
+    }
+
+    @Test
+    fun `omits null fields when explicitNulls is false`() {
+        val request = OptimizeRouteRequest(productIds = listOf("only-product"))
+
+        val encoded = json.encodeToString(request)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        // product_ids is always present
+        assertTrue(obj.containsKey("product_ids"))
+        // All optional fields must be omitted, not serialized as null
+        assertFalse("user_lat should be omitted", obj.containsKey("user_lat"))
+        assertFalse("user_lng should be omitted", obj.containsKey("user_lng"))
+        assertFalse("mode should be omitted", obj.containsKey("mode"))
+        assertFalse("max_stops should be omitted", obj.containsKey("max_stops"))
+        assertFalse("max_radius_miles should be omitted", obj.containsKey("max_radius_miles"))
+    }
+
+    @Test
+    fun `serializes empty product_ids as empty JSON array`() {
+        val request = OptimizeRouteRequest(productIds = emptyList())
+        val encoded = json.encodeToString(request)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        val productIds = obj["product_ids"]
+        assertTrue(productIds is JsonArray)
+        assertEquals(0, (productIds as JsonArray).size)
+    }
+}

--- a/android/app/src/test/java/com/example/android/data/repository/preferences/OptimizationPriorityTest.kt
+++ b/android/app/src/test/java/com/example/android/data/repository/preferences/OptimizationPriorityTest.kt
@@ -1,0 +1,33 @@
+package com.example.android.data.repository.preferences
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Locks in the mapping from user-facing priority to backend `mode`
+ * query parameter on `/routes/optimize`.
+ */
+class OptimizationPriorityTest {
+
+    @Test
+    fun `LowestCost maps to cost`() {
+        assertEquals("cost", OptimizationPriority.LowestCost.toBackendMode())
+    }
+
+    @Test
+    fun `ShortestRoute maps to distance`() {
+        assertEquals("distance", OptimizationPriority.ShortestRoute.toBackendMode())
+    }
+
+    @Test
+    fun `FastestTrip maps to stops`() {
+        assertEquals("stops", OptimizationPriority.FastestTrip.toBackendMode())
+    }
+
+    @Test
+    fun `every priority has a non-empty backend mode`() {
+        OptimizationPriority.values().forEach { priority ->
+            assertEquals(true, priority.toBackendMode().isNotBlank())
+        }
+    }
+}

--- a/android/app/src/test/java/com/example/android/data/repository/route/ApiRouteRepositoryTest.kt
+++ b/android/app/src/test/java/com/example/android/data/repository/route/ApiRouteRepositoryTest.kt
@@ -155,6 +155,52 @@ class ApiRouteRepositoryTest {
     }
 
     @Test
+    fun `optimizeRoute propagates imageUrl and categorySlug into RouteStopItem`() = runTest {
+        val item = RouteItem(
+            productId = "p-img",
+            name = "Whole Milk",
+            unitSize = "1 gal",
+            imageUrl = "https://example.com/milk.png",
+            categorySlug = "milk",
+            price = 4.99,
+            salePrice = null
+        )
+        val itemNoMedia = RouteItem(
+            productId = "p-bare",
+            name = "Mystery Item",
+            unitSize = "1 ct",
+            imageUrl = null,
+            categorySlug = null,
+            price = 1.00,
+            salePrice = null
+        )
+        val backendRoute = OptimizedRoute(
+            totalCost = 5.99,
+            stops = listOf(
+                RouteStop(
+                    store = Store(id = "store-A", name = "Trader Joe's"),
+                    items = listOf(item, itemNoMedia),
+                    subtotal = 5.99
+                )
+            )
+        )
+        val api = FakeNeighborlyApi(optimizeResult = Result.success(backendRoute))
+        val repo = ApiRouteRepository(api)
+
+        val plan = repo.optimizeRoute(
+            productIds = listOf("p-img", "p-bare"),
+            userLat = null,
+            userLng = null
+        ).getOrThrow()
+
+        val mappedItems = plan.stops.single().items
+        assertEquals("https://example.com/milk.png", mappedItems[0].imageUrl)
+        assertEquals("milk", mappedItems[0].categorySlug)
+        assertNull(mappedItems[1].imageUrl)
+        assertNull(mappedItems[1].categorySlug)
+    }
+
+    @Test
     fun `optimizeRoute propagates failure from the api`() = runTest {
         val boom = RuntimeException("backend exploded")
         val api = FakeNeighborlyApi(optimizeResult = Result.failure(boom))

--- a/android/app/src/test/java/com/example/android/data/repository/route/ApiRouteRepositoryTest.kt
+++ b/android/app/src/test/java/com/example/android/data/repository/route/ApiRouteRepositoryTest.kt
@@ -1,0 +1,259 @@
+package com.example.android.data.repository.route
+
+import com.example.android.data.api.NeighborlyApi
+import com.example.android.data.model.OptimizedRoute
+import com.example.android.data.model.Product
+import com.example.android.data.model.ProductCategory
+import com.example.android.data.model.ProductSearchResponse
+import com.example.android.data.model.RouteItem
+import com.example.android.data.model.RouteStop
+import com.example.android.data.model.Store
+import com.example.android.data.model.StoreProduct
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Hand-rolled fake of [NeighborlyApi]. Each method returns whatever is configured
+ * via the corresponding `*Result` field, so individual tests can stage either
+ * `Result.success` or `Result.failure` without pulling in a mocking library.
+ */
+private class FakeNeighborlyApi(
+    var optimizeResult: Result<OptimizedRoute> = Result.failure(IllegalStateException("not configured")),
+    var alternativesResult: Result<List<Product>> = Result.failure(IllegalStateException("not configured"))
+) : NeighborlyApi {
+
+    var lastOptimizeArgs: OptimizeArgs? = null
+        private set
+    var lastAlternativesProductId: String? = null
+        private set
+
+    data class OptimizeArgs(
+        val productIds: List<String>,
+        val userLat: Double?,
+        val userLng: Double?,
+        val mode: String?,
+        val maxStops: Int?,
+        val maxRadiusMiles: Double?
+    )
+
+    override suspend fun searchProducts(
+        query: String,
+        page: Int,
+        pageSize: Int
+    ): Result<ProductSearchResponse> = Result.failure(UnsupportedOperationException("not used"))
+
+    override suspend fun getProduct(id: String): Result<Product> =
+        Result.failure(UnsupportedOperationException("not used"))
+
+    override suspend fun optimizeRoute(
+        productIds: List<String>,
+        userLat: Double?,
+        userLng: Double?,
+        mode: String?,
+        maxStops: Int?,
+        maxRadiusMiles: Double?
+    ): Result<OptimizedRoute> {
+        lastOptimizeArgs = OptimizeArgs(productIds, userLat, userLng, mode, maxStops, maxRadiusMiles)
+        return optimizeResult
+    }
+
+    override suspend fun getAlternatives(productId: String): Result<List<Product>> {
+        lastAlternativesProductId = productId
+        return alternativesResult
+    }
+}
+
+class ApiRouteRepositoryTest {
+
+    @Test
+    fun `optimizeRoute maps stops to one-based indices and effective prices`() = runTest {
+        val saleItem = RouteItem(
+            productId = "p-sale",
+            name = "Milk",
+            unitSize = "1 gal",
+            price = 4.99,
+            salePrice = 3.49
+        )
+        val regularItem = RouteItem(
+            productId = "p-regular",
+            name = "Bread",
+            unitSize = "1 loaf",
+            price = 2.50,
+            salePrice = null
+        )
+
+        val backendRoute = OptimizedRoute(
+            totalCost = 6.99,
+            stops = listOf(
+                RouteStop(
+                    store = Store(id = "store-A", name = "Trader Joe's", address = "123 Main"),
+                    items = listOf(saleItem),
+                    subtotal = 3.49
+                ),
+                RouteStop(
+                    store = Store(id = "store-B", name = "Safeway"),
+                    items = listOf(regularItem),
+                    subtotal = 2.50
+                )
+            ),
+            itemsNotFound = listOf("avocado", "kale")
+        )
+
+        val api = FakeNeighborlyApi(optimizeResult = Result.success(backendRoute))
+        val repo = ApiRouteRepository(api)
+
+        val result = repo.optimizeRoute(
+            productIds = listOf("p-sale", "p-regular"),
+            userLat = 1.0,
+            userLng = 2.0,
+            mode = "cost",
+            maxStops = 4,
+            maxRadiusMiles = 5.0
+        )
+
+        assertTrue(result.isSuccess)
+        val plan = result.getOrThrow()
+
+        assertEquals(6.99, plan.totalCost!!, 0.0)
+        assertEquals(2, plan.stops.size)
+
+        // 1-based stop indices.
+        assertEquals(1, plan.stops[0].index)
+        assertEquals(2, plan.stops[1].index)
+
+        // Sale item: price = salePrice, originalPrice = price.
+        val firstStopItem = plan.stops[0].items.single()
+        assertEquals(3.49, firstStopItem.price!!, 0.0)
+        assertEquals(4.99, firstStopItem.originalPrice!!, 0.0)
+        assertTrue(firstStopItem.swapAvailable)
+
+        // Regular item: price = price, originalPrice = null (only set when on sale).
+        val secondStopItem = plan.stops[1].items.single()
+        assertEquals(2.50, secondStopItem.price!!, 0.0)
+        assertNull(secondStopItem.originalPrice)
+        assertTrue(secondStopItem.swapAvailable)
+
+        // itemsNotFound becomes RouteMissingItem entries (productId/null reason).
+        assertEquals(2, plan.missingItems.size)
+        assertEquals(listOf("avocado", "kale"), plan.missingItems.map { it.name })
+        plan.missingItems.forEach {
+            assertNull(it.productId)
+            assertNull(it.reason)
+        }
+
+        // Args are forwarded.
+        val args = api.lastOptimizeArgs!!
+        assertEquals(listOf("p-sale", "p-regular"), args.productIds)
+        assertEquals(1.0, args.userLat!!, 0.0)
+        assertEquals(2.0, args.userLng!!, 0.0)
+        assertEquals("cost", args.mode)
+        assertEquals(4, args.maxStops)
+        assertEquals(5.0, args.maxRadiusMiles!!, 0.0)
+    }
+
+    @Test
+    fun `optimizeRoute propagates failure from the api`() = runTest {
+        val boom = RuntimeException("backend exploded")
+        val api = FakeNeighborlyApi(optimizeResult = Result.failure(boom))
+        val repo = ApiRouteRepository(api)
+
+        val result = repo.optimizeRoute(
+            productIds = listOf("p1"),
+            userLat = null,
+            userLng = null,
+            mode = null,
+            maxStops = null,
+            maxRadiusMiles = null
+        )
+
+        assertTrue(result.isFailure)
+        assertEquals(boom, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `optimizeRoute maps an empty route with only missing items`() = runTest {
+        val backendRoute = OptimizedRoute(
+            totalCost = 0.0,
+            stops = emptyList(),
+            itemsNotFound = listOf("ghost")
+        )
+        val api = FakeNeighborlyApi(optimizeResult = Result.success(backendRoute))
+        val repo = ApiRouteRepository(api)
+
+        val plan = repo.optimizeRoute(
+            productIds = listOf("p1"),
+            userLat = null,
+            userLng = null
+        ).getOrThrow()
+
+        assertTrue(plan.stops.isEmpty())
+        assertEquals(1, plan.missingItems.size)
+        assertEquals("ghost", plan.missingItems.single().name)
+    }
+
+    @Test
+    fun `getSwapAlternatives maps Product to RouteSwapOption using best-price store`() = runTest {
+        val cheapStore = Store(id = "s-cheap", name = "BudgetMart")
+        val pricierStore = Store(id = "s-pricey", name = "FancyMart")
+
+        val product = Product(
+            id = "prod-1",
+            name = "Almond Milk",
+            unitSize = "1 qt",
+            upc = "0123456789",
+            productCategories = ProductCategory(id = "c1", name = "Dairy", slug = "milk"),
+            storeProducts = listOf(
+                StoreProduct(
+                    price = 5.99,
+                    salePrice = null,
+                    storeId = "s-pricey",
+                    stores = pricierStore
+                ),
+                StoreProduct(
+                    price = 4.50,
+                    salePrice = 3.99,
+                    storeId = "s-cheap",
+                    stores = cheapStore
+                )
+            )
+        )
+
+        val api = FakeNeighborlyApi(alternativesResult = Result.success(listOf(product)))
+        val repo = ApiRouteRepository(api)
+
+        val swaps = repo.getSwapAlternatives("prod-original").getOrThrow()
+
+        assertEquals("prod-original", api.lastAlternativesProductId)
+        assertEquals(1, swaps.size)
+        val swap = swaps.single()
+        assertEquals("prod-1", swap.productId)
+        assertEquals("Almond Milk", swap.name)
+        assertEquals("BudgetMart", swap.storeName)
+        assertEquals(3.99, swap.price!!, 0.0)
+        assertNull(swap.reason)
+    }
+
+    @Test
+    fun `getSwapAlternatives propagates failure from the api`() = runTest {
+        val boom = IllegalStateException("network down")
+        val api = FakeNeighborlyApi(alternativesResult = Result.failure(boom))
+        val repo = ApiRouteRepository(api)
+
+        val result = repo.getSwapAlternatives("prod-1")
+
+        assertTrue(result.isFailure)
+        assertEquals(boom, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `getSwapAlternatives returns empty list when api returns no products`() = runTest {
+        val api = FakeNeighborlyApi(alternativesResult = Result.success(emptyList()))
+        val repo = ApiRouteRepository(api)
+
+        val swaps = repo.getSwapAlternatives("prod-1").getOrThrow()
+        assertTrue(swaps.isEmpty())
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -8,6 +8,9 @@ espressoCore = "3.5.1"
 appcompat = "1.6.1"
 material = "1.10.0"
 ktor = "2.3.7"
+playServicesLocation = "21.3.0"
+coroutinesPlayServices = "1.9.0"
+coil = "2.7.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -21,6 +24,9 @@ ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-conte
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 ktor-client-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutinesPlayServices" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -11,6 +11,8 @@ ktor = "2.3.7"
 playServicesLocation = "21.3.0"
 coroutinesPlayServices = "1.9.0"
 coil = "2.7.0"
+mapbox = "11.7.1"
+mapboxCompose = "11.7.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,6 +29,8 @@ ktor-client-serialization-json = { group = "io.ktor", name = "ktor-serialization
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutinesPlayServices" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+mapbox-android = { group = "com.mapbox.maps", name = "android", version.ref = "mapbox" }
+mapbox-compose = { group = "com.mapbox.extension", name = "maps-compose", version.ref = "mapboxCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ coroutinesPlayServices = "1.9.0"
 coil = "2.7.0"
 mapbox = "11.7.1"
 mapboxCompose = "11.7.1"
+kotlinxCoroutinesTest = "1.9.0"
+kotlinxSerializationJson = "1.6.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,6 +33,8 @@ kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "ko
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 mapbox-android = { group = "com.mapbox.maps", name = "android", version.ref = "mapbox" }
 mapbox-compose = { group = "com.mapbox.extension", name = "maps-compose", version.ref = "mapboxCompose" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -16,6 +16,22 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://api.mapbox.com/downloads/v2/releases/maven")
+            authentication {
+                create<BasicAuthentication>("basic")
+            }
+            credentials {
+                username = "mapbox"
+                password = (rootProject.projectDir.resolve(".env").let { if (it.exists()) it.readLines() else emptyList() })
+                    .firstOrNull { it.startsWith("MAPBOX_DOWNLOADS_TOKEN=") }
+                    ?.substringAfter("=")
+                    ?.trim()
+                    ?.removeSurrounding("\"")
+                    ?: System.getenv("MAPBOX_DOWNLOADS_TOKEN")
+                    ?: ""
+            }
+        }
     }
 }
 

--- a/docs/android-stage1-plan.md
+++ b/docs/android-stage1-plan.md
@@ -1,0 +1,323 @@
+# Android Catch-Up — Stage 1: Core Trip Parity
+
+Date: 2026-05-02
+Predecessor: `docs/android-ios-catchup-plan.md` (2026-04-23)
+
+## Objective
+
+Bring the Android app to functional parity with iOS for the **primary user journey**: search → list → optimize route → see real map → swap items. After Stage 1, an Android user can plan and view the same shopping trip an iOS user can. Stage 1 closes Epic C in full and finishes the remaining Epic B items, plus lays foundational infrastructure (location, image loading, map SDK, connectivity) that Stage 2 also depends on.
+
+## Current State (entering Stage 1)
+
+Reference audit conducted 2026-05-02 against `main`.
+
+### Completed since the April 23 plan
+
+- Epic A (API foundation): `A1`, `A2`, `A3`, `A4` — all **DONE**
+  - `KtorNeighborlyApi` implements `searchProducts`, `getProduct`, `optimizeRoute`, `getAlternatives` with typed `Result<T>` and sealed `NeighborlyApiError`
+  - DTOs: `Product`, `ProductCategory`, `StoreProduct`, `Store`, `ProductSearchResponse`, `OptimizedRoute`, `RouteStop`, `RouteItem`
+  - `API_BASE_URL` loaded from `android/.env` via `BuildConfig`, with `MissingBaseUrl` error if blank
+- Epic B (grocery list):
+  - `B1` Local persistence — **DONE** (`SharedPreferencesGroceryListLocalDataSource` JSON store)
+  - `B2` Repository refactor — **PARTIAL** (repository pattern in place, but route state not shared, no Create Route button)
+  - `B3` Backend search — **DONE** (debounced `/products?q=…` with loading / no-results / error states)
+- Epic D:
+  - `D2` Local preference persistence — **DONE** (`SharedPreferencesPreferenceRepository`)
+
+### Outstanding gaps Stage 1 will close
+
+| ID | Gap | iOS reference |
+|----|-----|---------------|
+| 1 | Route repository wired to backend | `APIService.optimizeRoute` (APIService.swift:69-99) |
+| 2 | Shared route state across List ↔ Route screens | `RouteState` injected from `MainTabView` |
+| 3 | "Create Route" button on grocery list | `GroceryListView.swift:485-514` |
+| 4 | Location permissions + last-known location | `LocationHelper` (GroceryListView.swift:40-97) |
+| 5 | Real map: pins, polyline, ETA badges | `MapboxRouteMap.swift`, `MapboxDirectionsService.swift` |
+| 6 | Swap alternatives flow | `SwapSheet` (RouteView.swift:417-528) |
+| 7 | Product images via Coil | `AsyncImage` everywhere |
+| 8 | Multi-store pricing UI in product / item detail sheets | `ProductDetailSheet`, `ItemDetailSheet` (GroceryListView.swift:756-1036) |
+| 9 | Sale strikethrough + out-of-stock label | All product surfaces |
+| 10 | Network reconnect → price refresh | `NetworkMonitor.didReconnect` (GroceryListView.swift:9-36) |
+| 11 | Send `mode`, `max_stops`, `max_radius_miles` to `/routes/optimize` | GroceryListView.swift:536-544 |
+
+## Workstreams
+
+### S1.1 — Wire `RouteRepository` to backend
+
+**Goal:** replace `UnavailableRouteRepository` with a real implementation calling `NeighborlyApi.optimizeRoute` and `getAlternatives`.
+
+**Changes:**
+
+- New `ApiRouteRepository` implementing `RouteRepository`
+- Extend `OptimizeRouteRequest` (`data/model/RouteModels.kt:45-53`) with `mode: String?`, `maxStops: Int?`, `maxRadiusMiles: Double?` (all `@SerialName`-mapped)
+- Map `OptimizationPriority` → backend mode (`LowestCost` → `"cost"`, `ShortestRoute` → `"distance"`, `FastestTrip` → `"stops"`) — mirror iOS `Priority.backendMode` (PreferencesView.swift:23-29)
+
+**Files touched:**
+
+- `android/app/src/main/java/com/example/android/data/repository/RouteRepository.kt`
+- `android/app/src/main/java/com/example/android/data/api/NeighborlyApi.kt`
+- `android/app/src/main/java/com/example/android/data/model/RouteModels.kt`
+
+**Acceptance:**
+
+- Calling `RouteRepository.optimizeRoute` reaches the backend and returns a parsed `OptimizedRoute` or a typed error
+- The 4xx / 5xx body from the backend surfaces in `NeighborlyApiError.Server.responseBody`
+- Unit test: round-trip JSON parse for an optimize-route response sample
+
+### S1.2 — Share route state across screens
+
+**Goal:** the same `RouteViewModel` (or scoped `RouteState`) is consumed by `GroceryListScreen` and `RouteScreen`, so creating a route on one screen is visible on the other.
+
+**Changes:**
+
+- Hoist `RouteViewModel` to activity scope (or introduce a shared `RouteStateHolder` in DI)
+- `RouteScreen` reads from the same instance instead of constructing its own (`AppScaffold.kt:59`)
+- Add empty / loading / error rendering branches (UI is already drafted)
+
+**Files touched:**
+
+- `MainActivity.kt` or DI module
+- `ui/AppScaffold.kt`
+- `ui/route/RouteScreen.kt`
+- `ui/lists/GroceryListScreen.kt`
+
+**Acceptance:**
+
+- Optimizing a route from the grocery list updates `RouteScreen` without re-instantiating the view model
+- Navigating away and back to `RouteScreen` preserves the optimized route in memory
+
+### S1.3 — "Create Route" button on grocery list
+
+**Goal:** primary action button at the bottom of the grocery list that triggers route optimization.
+
+**Changes:**
+
+- Bottom-anchored CTA, enabled only when the list contains items with non-null `productId`
+- Tapping calls `ShopperViewModel.createRoute()`, which collects product IDs, requests location, and invokes `RouteRepository.optimizeRoute(productIds, lat?, lng?, mode, maxStops, maxRadius)`
+- On success, navigate to the Route tab; on `noRoute = true`, surface the reason in a snackbar; on transport error, show a snackbar with retry
+
+**Files touched:**
+
+- `viewmodel/shopper/ShopperViewModel.kt`
+- `ui/lists/GroceryListScreen.kt`
+- Navigation host (route to `Route` tab)
+
+**Acceptance:**
+
+- Button is hidden when list has no priced items
+- A successful optimize switches tabs and shows real data on `RouteScreen`
+- An empty-product-IDs case shows a user-facing error rather than calling the API
+
+### S1.4 — Location permissions + last-known location
+
+**Goal:** request location at the moment the user taps "Create Route", with a 3 s timeout and silent fallback to "no location".
+
+**Changes:**
+
+- Add to `AndroidManifest.xml`:
+  - `<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />`
+  - `<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />`
+- New `LocationHelper` using `FusedLocationProviderClient` (Google Play Services Location)
+- `requestLocation()` returns `Result<LatLng?>` with a 3 s timeout (matches iOS `LocationHelper`:60)
+- Permission rationale dialog on first request; denial returns `null` and the optimize proceeds without coords
+
+**Files touched:**
+
+- `android/app/src/main/AndroidManifest.xml`
+- New `data/location/LocationHelper.kt`
+- `viewmodel/shopper/ShopperViewModel.kt`
+
+**Acceptance:**
+
+- Granting permission attaches `user_lat` / `user_lng` to the optimize call
+- Denying or timing out still produces a route (without location tie-breaker)
+- Permission state survives process death
+
+### S1.5 — Add map SDK and render route
+
+**Goal:** real map on `RouteScreen` with numbered store pins, user puck, walking polyline, and per-leg ETA badges, matching iOS `MapboxRouteMap.swift`.
+
+**Decision:** **Mapbox**. Rationale: iOS already uses Mapbox Directions for ETA; reusing the same waypoint contract avoids a divergent map experience between platforms, and the `MapboxDirectionsService` response shape is portable. Google Maps is the alternative if Mapbox token provisioning is a blocker — call out in the implementation kickoff.
+
+**Changes:**
+
+- Add Mapbox Maps SDK + Directions to `gradle/libs.versions.toml` and `app/build.gradle.kts`
+- Add `MAPBOX_ACCESS_TOKEN` to `android/.env.example`, load via `BuildConfig`
+- New `ui/route/MapboxRouteMap.kt` Compose wrapper:
+  - Streets style, `Puck2D` with heading
+  - `PointAnnotationGroup` of numbered pins (1, 2, 3, …)
+  - `PolylineAnnotation` for the walking route, fall back to straight lines if Directions API fails (mirror MapboxRouteMap.swift:60)
+  - ETA badge per pin, computed `int(max(1, duration_seconds / 60))`
+- New `data/maps/MapboxDirectionsService.kt` calling Directions API v5 (walking, geojson)
+- Replace the placeholder card on `RouteScreen` with the real map
+
+**Files touched:**
+
+- `gradle/libs.versions.toml`, `app/build.gradle.kts`
+- `android/.env.example`
+- `AndroidManifest.xml` (Mapbox metadata)
+- `ui/route/RouteScreen.kt`
+- New `ui/route/MapboxRouteMap.kt`
+- New `data/maps/MapboxDirectionsService.kt`
+
+**Acceptance:**
+
+- Pins are numbered in route order and tappable to focus a single stop
+- Polyline renders between stops, including from user location when available
+- ETAs render as "X min" badges; falling back to straight lines when Directions returns an error does not crash
+
+### S1.6 — Swap alternatives flow
+
+**Goal:** tapping a route item opens the alternatives sheet, selecting one updates the persisted grocery list and re-optimizes.
+
+**Changes:**
+
+- Wire the existing swap dialog (`RouteScreen.kt:411-453`) to `RouteRepository.getSwapAlternatives(productId)`
+- On selection: `GroceryListRepository.replaceProduct(oldUpc, newProduct)` then `RouteRepository.optimizeRoute(...)` with the updated product list
+- Loading / error / empty branches in the sheet
+
+**Files touched:**
+
+- `viewmodel/route/RouteViewModel.kt`
+- `viewmodel/shopper/ShopperViewModel.kt`
+- `data/repository/GroceryListRepository.kt`
+- `ui/route/RouteScreen.kt`
+
+**Acceptance:**
+
+- Tapping any route item opens the sheet; alternatives load from `/products/:id/alternatives`
+- Selecting an alternative replaces the grocery item and re-renders the route with the new totals
+- Cancelling the sheet leaves the list and route unchanged
+
+### S1.7 — Image loading via Coil
+
+**Goal:** product images render everywhere they appear on iOS, with a category-emoji fallback.
+
+**Changes:**
+
+- Add `coil-compose` to dependencies
+- Replace emoji-only thumbnails in: search rows, grocery item rows, route item rows, swap dialog, future detail sheets (S1.8) — wherever `imageUrl` is non-null
+- `error` and `placeholder` slots use the existing `ProductCategory.emoji` fallback
+
+**Files touched:**
+
+- `gradle/libs.versions.toml`, `app/build.gradle.kts`
+- `ui/lists/GroceryListScreen.kt`
+- `ui/route/RouteScreen.kt`
+- `ui/components/ProductImage.kt` (new shared composable)
+
+**Acceptance:**
+
+- Search rows show real product images when available
+- Network errors fall back to the category emoji silently
+- No image flicker on list scroll (Coil's default disk cache enabled)
+
+### S1.8 — Product / item detail sheets
+
+**Goal:** match iOS `ProductDetailSheet` and `ItemDetailSheet` (GroceryListView.swift:756-1036): image, brand, size, sorted multi-store prices, sale strikethrough, in-stock label, quantity controls.
+
+**Changes:**
+
+- Tap on a search result opens a `ProductDetailSheet` with an "Add" button (do not add directly on row tap — current behavior diverges from iOS)
+- Tap on a list item opens `ItemDetailSheet` with quantity +/- and remove
+- Both sheets render store-product rows sorted by effective price ascending
+- Render sale price with strikethrough on the original (iOS:840-857, 988-1010)
+- Out-of-stock items show a label and are visually de-emphasized
+
+**Files touched:**
+
+- New `ui/lists/ProductDetailSheet.kt`
+- New `ui/lists/ItemDetailSheet.kt`
+- `ui/lists/GroceryListScreen.kt`
+- `viewmodel/shopper/ShopperViewModel.kt` (sheet state)
+
+**Acceptance:**
+
+- Search row tap → sheet → "Add" closes the sheet and increments / inserts the item
+- Multi-store pricing visibly matches the iOS layout (price, store name, sale strikethrough, OOS)
+- Sheet dismiss does not trigger an add
+
+### S1.9 — Network reconnect → price refresh
+
+**Goal:** when the device loses and regains connectivity, prices for items with `productId` are silently refreshed (matches iOS `NetworkMonitor.didReconnect`, GroceryListView.swift:9-36).
+
+**Changes:**
+
+- New `NetworkMonitor` wrapping `ConnectivityManager.NetworkCallback`, exposed as a `Flow<Boolean>`
+- `ShopperViewModel` collects the flow; on a `false → true` transition it calls `repository.refreshPrices()`
+- Refresh failures do not clear the list or block normal operations
+
+**Files touched:**
+
+- New `data/connectivity/NetworkMonitor.kt`
+- `viewmodel/shopper/ShopperViewModel.kt`
+
+**Acceptance:**
+
+- Toggling airplane mode off triggers exactly one refresh per reconnect (debounced)
+- Failure path preserves the list and shows a snackbar but does not navigate or wipe state
+
+### S1.10 — Verification
+
+**Manual smoke checklist:**
+
+1. Sign in
+2. Search "milk", confirm results render with images
+3. Open the product detail sheet, add to list
+4. Force-stop and reopen the app; confirm the list persists
+5. Tap "Create Route"; deny location → route still optimizes
+6. Tap "Create Route" again; grant location → route uses lat / lng
+7. On the Route tab: pins numbered, polyline visible, ETA badges render
+8. Tap an item, swap to an alternative; route re-optimizes with new totals
+9. Toggle airplane mode on / off on the list screen; observe one refresh
+10. Sign out
+
+**Unit tests:**
+
+- `OptimizeRouteRequest` snake_case mapping (mode, max_stops, max_radius_miles)
+- `OptimizedRoute` JSON parse for happy path + `noRoute` branch
+- `LocationHelper` denied-permission returns null; timeout returns null
+- `OptimizationPriority.toBackendMode()` mapping
+- `NetworkMonitor` emits a single reconnect event for an off → on toggle
+
+**Files touched:** `android/app/src/test/...`
+
+## Sequencing & Parallelization
+
+```
+S1.1 ─┐
+      ├─> S1.2 ─> S1.3 ─┐
+S1.4 ─┘                  ├─> S1.6
+                         │
+S1.5 (parallel from start, gated by S1.1) ─┘
+
+S1.7 (parallel from start, no deps)
+S1.8 (after S1.7)
+S1.9 (parallel from start)
+S1.10 (after all)
+```
+
+Two engineers can work S1.1 / S1.2 / S1.3 (the optimize path) while a second pair handles S1.5 (map) and S1.7 / S1.8 (images + sheets).
+
+## Risks & Open Questions
+
+- **Mapbox token provisioning + billing.** Coordinate with whoever owns the iOS Mapbox account before adding the SDK.
+- **Backend `mode` parameter behavior.** iOS already sends `"distance"` and `"stops"` even though the backend currently only optimizes for cost. Confirm with backend that unsupported modes don't 5xx.
+- **Emulator location.** Android emulator GPS is awkward without setting it via the extended controls; document the manual override in the smoke checklist.
+- **Mapbox SDK size.** Adds ~15 MB to the APK. If size becomes a concern, evaluate `mapbox-maps-android` lite vs full.
+- **`FusedLocationProviderClient` requires Google Play Services.** Document fallback (likely "no location, optimize without coords") for non-GMS devices.
+
+## Stage 1 Deliverables
+
+- All Epic C items (`C1` – `C6`) closed
+- Epic B `B4` and `B5` closed
+- Foundational infrastructure (location, map, image loading, connectivity) ready for Stage 2
+- An Android user can complete the same end-to-end shopping trip an iOS user can
+
+## Out of Scope (handled in Stage 2)
+
+- Wellness violations and warnings
+- Recipe generator and home recipe widget
+- Preferences sync to Supabase
+- Home dashboard dynamic data
+- Theme cleanup, password reset, additional test coverage

--- a/docs/android-stage2-plan.md
+++ b/docs/android-stage2-plan.md
@@ -1,0 +1,313 @@
+# Android Catch-Up — Stage 2: Wellness, Recipes, Preferences Sync & Polish
+
+Date: 2026-05-02
+Predecessors: `docs/android-ios-catchup-plan.md` (2026-04-23), `docs/android-stage1-plan.md` (2026-05-02)
+
+## Objective
+
+Complete iOS feature parity for surfaces *outside* the primary trip flow: wellness violations everywhere products appear, the recipe generator and home recipe widget, server-synced preferences, a dynamic home dashboard, plus the quality cleanup deferred from Epic D. After Stage 2, every screen and feature shipping on iOS has an Android counterpart.
+
+## Why a Stage 2
+
+Two new iOS features merged in late April 2026 — the **recipe generator** (PR #60, merged 2026-04-30) and **wellness violation warnings** — sit on top of, but don't block, the trip optimization path. Splitting them out of Stage 1 lets Stage 1 ship as a self-contained "trip parity" release. Stage 2 also picks up the Epic D items (`D1`, `D3`, `D4`, `D5`) that were always intended to come after the core path stabilized.
+
+## Current State (entering Stage 2)
+
+Stage 2 assumes Stage 1 has shipped: route repository wired, shared route state, location, Mapbox, swap flow, Coil image loading, detail sheets, network reconnect.
+
+### Outstanding gaps Stage 2 will close
+
+| ID | Gap | iOS reference |
+|----|-----|---------------|
+| 12 | `ProductNutrition` model + violation engine | `Product.swift:35-58` |
+| 13 | Wellness chips on search rows + grocery items | `GroceryListView.swift:449-455` |
+| 14 | `WellnessPanel` in product detail sheet | `GroceryListView.swift:1073-1162` |
+| 15 | `WellnessWarningSheet` confirmation before route optimize | `GroceryListView.swift:678-693, 1166-1229` |
+| 16 | Recipe model (`RecipeSuggestion`, `RecipeRequestPayload`, nutrition targets) | `Models/RecipeSuggestion.swift` |
+| 17 | `/recipes/generate` endpoint on `NeighborlyApi` | `APIService.swift:116-133` |
+| 18 | Featured recipe widget on Home + detail screen | `HomeView.swift:216-333`, `RecipeDetailView.swift` |
+| 19 | Auto-regenerate recipe on preferences change | `HomeViewModel.swift:56-74` |
+| 20 | Preferences upsert / fetch against Supabase `user_preferences` | `PreferencesService.swift` |
+| 21 | Home dashboard driven by real data | `HomeView.swift` (partially live on iOS) |
+| 22 | Theme finalization (D1 finish) | n/a — internal cleanup |
+| 23 | Password reset, email verification UI | `LoginView.swift:56-63` |
+| 24 | Test coverage for parsing + view models | iOS recipe tests (commit 437229a) |
+
+## Workstreams
+
+### S2.1 — `ProductNutrition` model + violation engine
+
+**Goal:** port the iOS data model and violation logic so any product can be checked against a `PreferenceState`.
+
+**Changes:**
+
+- Add `ProductNutrition` to `data/model/Product.kt`, mirroring `Product.swift:35-58`:
+  - Numerics: `servingSizeG`, `servingsPerContainer`, `caloriesKcal`, `proteinG`, `fatG`, `carbsG`, `fiberG`, `sodiumMg`, `cholesterolMg`, `sugarG` (all nullable)
+  - Allergen flags: `containsDairy`, `containsPeanuts`, `containsShellfish`, `containsWheat` (`Boolean?`)
+- New `domain/wellness/Violations.kt`:
+  - Sealed `WellnessViolation`: `Allergen(name)`, `NutrientExceeded(name, actual, limit)`
+  - Extension `ProductNutrition.violations(against: PreferenceState): List<WellnessViolation>`
+- Cache nutrition responses by `productId` in `ShopperViewModel` (mirrors iOS `nutritionCache`, GroceryListView.swift:130). Populate from `getProduct` lazily.
+
+**Files touched:**
+
+- `data/model/Product.kt`
+- New `domain/wellness/Violations.kt`
+- `viewmodel/shopper/ShopperViewModel.kt`
+
+**Acceptance:**
+
+- A `Product` with `containsPeanuts = true` produces an `Allergen` violation when prefs include `avoidPeanuts`
+- Nutrient violations only fire when `wellnessEnabled = true` and the field is non-empty / non-zero
+- Unit tests cover both branches plus the no-violation happy path
+
+### S2.2 — Wellness warning UI
+
+**Goal:** the user always knows when a product violates their preferences, both at-a-glance and before committing to a route.
+
+**Changes:**
+
+- **Allergen chip row** on search-result rows and grocery items (red exclamation + violated allergen names) — mirror GroceryListView.swift:449-455
+- **`WellnessPanel`** in the product detail sheet (Stage 1 S1.8) — mirror GroceryListView.swift:1073-1162
+  - Lists allergens triggered, nutrient overruns ("Sodium: 800 mg, limit 600 mg")
+- **`WellnessWarningSheet`** — confirmation modal that intercepts route creation when any list item violates preferences (iOS GroceryListView.swift:678-693, 1166-1229)
+  - Lists offending products with their violations
+  - "Optimize anyway" / "Cancel" buttons; only "Optimize anyway" proceeds to `RouteRepository.optimizeRoute`
+
+**Files touched:**
+
+- New `ui/lists/WellnessPanel.kt`
+- New `ui/lists/WellnessWarningSheet.kt`
+- `ui/lists/GroceryListScreen.kt`
+- `ui/lists/ProductDetailSheet.kt` (built in Stage 1)
+- `viewmodel/shopper/ShopperViewModel.kt`
+
+**Acceptance:**
+
+- A list containing a peanut product with `avoidPeanuts = true` shows the warning sheet on "Create Route"
+- "Cancel" leaves the list and route untouched
+- "Optimize anyway" proceeds to optimize without further prompts
+- Disabling wellness in preferences hides all chips and skips the warning sheet
+
+### S2.3 — Recipe generator (model + API + repository)
+
+**Goal:** a server-generated recipe based on the user's preferences.
+
+**Changes:**
+
+- New `data/model/RecipeSuggestion.kt`:
+  - `RecipeSuggestion`: `title`, `summary`, `whyItMatches: List<String>`, `prepMinutes`, `cookMinutes`, `servings`, `ingredients: List<String>`, `steps: List<String>`, `nutritionNotes: List<String>`
+  - `RecipeRequestPayload`: `dietaryPreferences: List<String>`, `avoidIngredients: List<String>`, `nutritionTargets: NutritionTargetsPayload?`
+  - `NutritionTargetsPayload`: `cholesterolMg`, `sodiumMg`, `sugarG` (nullable)
+- Extend `NeighborlyApi`:
+  - `suspend fun generateRecipe(payload: RecipeRequestPayload): Result<RecipeSuggestion>` → POST `/recipes/generate`
+- New `data/repository/RecipeRepository.kt`:
+  - `generate(force: Boolean = false): Result<RecipeSuggestion>`
+  - Caches the last `RecipeRequestPayload` and returned `RecipeSuggestion`; only re-requests when payload changes or `force = true` (mirror HomeViewModel.swift:56-74)
+- New extension `PreferenceState.toRecipeRequestPayload()` mirroring iOS `Preferences.recipeRequestPayload` (RecipeSuggestion.swift:36-68)
+
+**Files touched:**
+
+- New `data/model/RecipeSuggestion.kt`
+- `data/api/NeighborlyApi.kt`
+- New `data/repository/RecipeRepository.kt`
+- New `domain/preferences/RecipePayloadMapper.kt`
+
+**Acceptance:**
+
+- Calling `RecipeRepository.generate()` twice with unchanged preferences makes one network call and returns the cache the second time
+- `force = true` always re-requests
+- Unit test: round-trip parse of a recipe response sample; payload mapping for a "vegan, avoid peanuts" preference set
+
+### S2.4 — Featured recipe widget on Home + detail screen
+
+**Goal:** a card on the Home screen showing the current recipe with a refresh button, and a detail screen on tap.
+
+**Changes:**
+
+- New `ui/home/components/FeaturedRecipeCard.kt`:
+  - Title, summary, "why it matches" bullets, refresh icon, tap-through arrow
+  - Loading shimmer + error states (mirror HomeView.swift:292-318)
+- New `ui/home/RecipeDetailScreen.kt` mirroring `RecipeDetailView.swift`:
+  - Pills for prep / cook / servings
+  - Numbered ingredients, steps, "why it matches", nutrition notes
+- `HomeViewModel` owns `featuredRecipe: RecipeSuggestion?`, `isLoadingRecipe`, `recipeError`
+- Auto-regenerate on `PreferenceState` change (debounce in the view model, skip if cached payload unchanged — iOS HomeViewModel.swift:56-74)
+
+**Files touched:**
+
+- `ui/home/HomeScreen.kt`
+- New `ui/home/components/FeaturedRecipeCard.kt`
+- New `ui/home/RecipeDetailScreen.kt`
+- `viewmodel/home/HomeViewModel.kt`
+- Navigation host (route to recipe detail)
+
+**Acceptance:**
+
+- Home renders a recipe card on first launch (after preferences load)
+- Editing preferences triggers regeneration without an explicit user action
+- Refresh button forces a regenerate
+- Tapping the card opens the detail screen with full recipe content
+- Network errors render an inline error state, not a crash
+
+### S2.5 — Preferences ↔ Supabase sync
+
+**Goal:** preferences edited on Android persist to the same Supabase `user_preferences` row that iOS reads, and vice versa.
+
+**Changes:**
+
+- Install `Postgrest` plugin on `SupabaseClient` (`data/SupabaseClient.kt:1-13`)
+- New `data/repository/PreferenceRemoteRepository.kt`:
+  - `fetch(userId): Result<PreferenceState?>` reads `user_preferences` by `user_id`
+  - `save(prefs, userId)` upserts on `user_id` conflict
+  - Conversion helpers: miles ↔ km (`× 0.621371` / `× 1.60934`), `0.0` km = "unlimited" → slider value `11` (mirror PreferencesService.swift:86-91)
+- `ShopperViewModel`:
+  - On preferences screen open, fetch from Supabase and reconcile with local state — local takes precedence on the user's session, remote takes precedence on first open after login
+  - Save button writes to both local and remote
+- Confirm column names match iOS exactly so a user signing into both platforms sees the same preferences
+
+**Files touched:**
+
+- `data/SupabaseClient.kt`
+- New `data/repository/PreferenceRemoteRepository.kt`
+- `viewmodel/shopper/ShopperViewModel.kt`
+- `ui/preferences/PreferencesScreen.kt` (Save button wiring)
+
+**Acceptance:**
+
+- Saving on Android updates the row visible in Supabase Studio
+- Logging in with the same user on iOS shows the values just saved on Android
+- Network failures during fetch fall back to local preferences without blocking the UI
+- "Unlimited" sentinel is preserved across the round trip
+
+### S2.6 — Home dashboard off static data
+
+**Goal:** the home metrics and "Start Trip" CTA reflect real state instead of the hardcoded values currently in `HomeViewModel`.
+
+**Changes:**
+
+- Replace hardcoded metrics (HomeViewModel.kt:23-32) with:
+  - **Items tracked**: count of persisted grocery items
+  - **Latest trip**: total cost, store count, item count from the most recent `OptimizedRoute` in shared `RouteState`
+  - **Budget / savings**: keep static demo as a fallback, override with real values when available
+- "Start Trip" button: enabled only when an optimized route exists; tapping switches to the Route tab
+- Remove static `HomeViewModel.routeStops` (3 hardcoded stops) and render either the real route preview or an empty state
+
+**Files touched:**
+
+- `viewmodel/home/HomeViewModel.kt`
+- `ui/home/HomeScreen.kt`
+
+**Acceptance:**
+
+- A fresh user with no list and no route sees the empty / demo state
+- After adding items, the count updates live
+- After optimizing a route, the home preview shows real store count and total cost
+- "Start Trip" is disabled when no route exists
+
+### S2.7 — Theme cleanup (D1 finish)
+
+**Goal:** no screen defines its own color literals; everything routes through `NeighborlyTheme`.
+
+**Changes:**
+
+- Move local color constants out of `LoginScreen.kt:41-43` and any other screens with `Color(0xFF…)` literals into `ui/theme/NeighborlyTheme.kt`
+- Audit `GroceryListScreen.kt`, `RouteScreen.kt`, `PreferencesScreen.kt`, `HomeScreen.kt` for raw colors and replace with theme tokens
+- Centralize spacing tokens already defined in `NeighborlySpacing` (apply where dp literals leak)
+
+**Files touched:**
+
+- `ui/theme/NeighborlyTheme.kt`
+- All `ui/**/*Screen.kt` files
+
+**Acceptance:**
+
+- Grep `Color(0xFF` in `ui/` returns only `NeighborlyTheme.kt`
+- Light / dark mode switch produces consistent results across all screens (matches iOS f77cd02 behavior)
+
+### S2.8 — Auth polish
+
+**Goal:** complete the auth flow with the missing affordances.
+
+**Changes:**
+
+- Password reset entry point on `LoginScreen` ("Forgot password?")
+  - Calls Supabase `resetPasswordForEmail(email)` and shows a confirmation snackbar
+- Sign-up confirmation message when Supabase requires email verification (mirror LoginView.swift:56-63)
+  - `LoginViewModel.onSubmit` already returns whether a session was obtained immediately; surface the "check your email" alert when not
+
+**Files touched:**
+
+- `viewmodel/login/LoginViewModel.kt`
+- `ui/login/LoginScreen.kt`
+
+**Acceptance:**
+
+- Tapping "Forgot password?" with a registered email triggers the Supabase flow and shows a confirmation
+- Signing up with email verification enabled in Supabase shows the confirmation message instead of leaving the user on the login form silently
+
+### S2.9 — Test coverage (D5)
+
+**Goal:** lock in the parity gains with unit tests so future regressions show up in CI.
+
+**Changes:**
+
+- API parsing tests (`data/api/`):
+  - Product search response (happy path + empty)
+  - Optimize route response (happy path + `noRoute = true` branch)
+  - Recipe response
+- Repository tests with fake `NeighborlyApi`:
+  - `GroceryListRepository.addOrIncrement` UPC-merges quantity
+  - `GroceryListRepository.refreshPrices` ignores per-item failures
+  - `RouteRepository.optimizeRoute` propagates typed errors
+  - `RecipeRepository` skips redundant calls when payload unchanged
+- View-model tests (`viewmodel/`):
+  - `ShopperViewModel` search debounce + cancellation
+  - `RouteViewModel` swap → re-optimize sequence
+  - `HomeViewModel` regenerates recipe on preferences change
+
+**Files touched:** `app/src/test/...`
+
+**Acceptance:**
+
+- `./gradlew test` runs the new tests in CI
+- Tests cover at minimum every endpoint parser and every repository public method
+
+## Sequencing & Parallelization
+
+```
+Independent tracks (can start in parallel once Stage 1 is in main):
+
+  Track A — Wellness:       S2.1 ─> S2.2
+  Track B — Recipe:         S2.3 ─> S2.4
+  Track C — Prefs sync:     S2.5
+  Track D — Home polish:    S2.6  (depends on Stage 1 shared RouteState)
+  Track E — Cleanup:        S2.7, S2.8 (no deps)
+
+Final:                       S2.9 (after each track lands its surface area)
+```
+
+Tracks A through E are independently shippable. A four-engineer team can take one track each; a smaller team should sequence Track A → Track B → Track C → Track D → Track E (highest user-visible value first).
+
+## Risks & Open Questions
+
+- **`user_preferences` schema parity.** Confirm column names are identical to iOS before wiring `PreferenceRemoteRepository`. Mismatches will silently corrupt cross-platform sync.
+- **Recipe API rate limits / cost.** Recipe generation likely calls an LLM; confirm with backend that doubling traffic from Android is within budget. Caching by payload (S2.3) mitigates but doesn't eliminate.
+- **Dietary preference cardinality.** iOS uses `dietVegan` / `dietGlutenFree` etc. as separate booleans. Preserve the same names and serialization so cross-platform DB rows stay readable.
+- **Wellness UX on a long list.** If a user's grocery list has 20+ violating items, the warning sheet may feel overwhelming. iOS doesn't truncate; mirror that for parity but flag for product review post-launch.
+- **Home dashboard "savings" metric.** iOS still has it hardcoded. Decide whether to leave Android matching that demo behavior or compute a real number from sale prices in the latest route.
+
+## Stage 2 Deliverables
+
+- Wellness violations surfaced everywhere products appear, with a confirmation sheet before route optimization
+- Recipe generator and home recipe widget at iOS parity
+- Preferences synced bidirectionally with Supabase
+- Home dashboard reflecting real list and route state
+- Theme cleanup (`D1`) finished, password reset shipped, base test coverage in CI
+
+## Out of Scope
+
+- Push notifications (iOS doesn't have them either; deferred indefinitely)
+- Deep links (same)
+- Analytics / telemetry (cross-platform decision, not Android-specific)
+- Vendor / admin surfaces (web-only on iOS as well)

--- a/ios/run.sh
+++ b/ios/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Navigate to the iOS project root (this script lives in /ios)
+IOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${IOS_DIR}"
+
+SCHEME="Neighborly"
+PROJECT_PATH="Neighborly/Neighborly.xcodeproj"
+# Use an existing simulator from your xcodebuild output (iPhone 16)
+DESTINATION='platform=iOS Simulator,name=iPhone 16,OS=18.2'
+
+echo "Building and running scheme '${SCHEME}' from '${PROJECT_PATH}'..."
+echo "Destination: ${DESTINATION}"
+echo
+
+if command -v xcpretty >/dev/null 2>&1; then
+  xcodebuild \
+    -project "${PROJECT_PATH}" \
+    -scheme "${SCHEME}" \
+    -destination "${DESTINATION}" \
+    clean build \
+    | xcpretty
+else
+  echo "xcpretty not found; showing raw xcodebuild output."
+  xcodebuild \
+    -project "${PROJECT_PATH}" \
+    -scheme "${SCHEME}" \
+    -destination "${DESTINATION}" \
+    clean build
+fi
+
+# If you just want to build & run (no tests), you can instead do:
+# xcodebuild -project "${PROJECT_PATH}" -scheme "${SCHEME}" -destination "${DESTINATION}" clean build

--- a/web/output.txt
+++ b/web/output.txt
@@ -1,0 +1,26 @@
+
+> neighborly@0.1.0 dev
+> next dev
+
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.91.177:3000
+- Environments: .env
+
+✓ Starting...
+✓ Ready in 448ms
+ GET /settings 404 in 433ms (compile: 364ms, render: 68ms)
+ GET /settings 404 in 34ms (compile: 5ms, render: 28ms)
+ GET /settings 404 in 30ms (compile: 5ms, render: 25ms)
+ GET / 200 in 110ms (compile: 46ms, render: 63ms)
+ GET /auth/login 200 in 84ms (compile: 68ms, render: 16ms)
+ GET /dashboard 404 in 38ms (compile: 6ms, render: 32ms)
+ GET /userdashboard 200 in 107ms (compile: 74ms, render: 33ms)
+ GET / 200 in 21ms (compile: 3ms, render: 18ms)
+ POST /userdashboard 303 in 331ms (compile: 6ms, render: 326ms)
+ GET / 200 in 10ms (compile: 2ms, render: 8ms)
+ GET /auth/login 200 in 27ms (compile: 4ms, render: 23ms)
+ GET /userdashboard 200 in 22ms (compile: 4ms, render: 17ms)
+ POST /auth/login 303 in 340ms (compile: 3ms, render: 337ms)
+ GET /vendordashboard 200 in 233ms (compile: 183ms, render: 50ms)
+[?25h


### PR DESCRIPTION
## Summary                                                                    
                                                                          
Brings Android up to iOS parity on the **primary trip flow**: search → list → optimize route → real Mapbox map → swap items. 

## What's new                                                                                                                             
**Trip path**                                                                 
- `ApiRouteRepository` wired to `NeighborlyApi.optimizeRoute` /  `getAlternatives`       
- `RouteViewModel` hoisted to activity scope so the grocery list and route screen share one instance    
- "Create Route" button on the grocery list with location permission flow + 3s `FusedLocationProvider` lookup, silent fallback on denial
- Real `MapboxRouteMap` v11.7.1: numbered pins, user puck, walking polyline from the Directions API (with straight-line fallback), per-leg ETA badges as ViewAnnotations, **pin tap → focus + "All stops" reset** 
- Swap alternatives flow: select an alternative → fetch full product → replace persisted list item → re-optimize with current preferences 
                                                                          
**Grocery list polish**                               
- `ProductDetailSheet` and `ItemDetailSheet` Material 3 modal sheets with image, brand, sorted multi-store prices (sale strikethrough, out-of-stock pill), quantity controls                                            
- Coil-backed `ProductImage` shared composable replaces emoji-only thumbnails on search rows, list items, and route item rows with a category-emoji fallback                                                              
- `NetworkMonitor` wraps `ConnectivityManager.NetworkCallback` as a `Flow<Boolean>`; `ShopperViewModel` re-fetches prices on `false → true` transitions without clearing the list on failure 
                                                                          
**Foundation**                                                                
- `OptimizeRouteRequest` extended with `mode` / `max_stops` / `max_radius_miles` to match the iOS contract; `OptimizationPriority.toBackendMode()` mapping                                
- `RouteStopItem` carries `imageUrl` + `categorySlug` 
- New `NeighborlyApp` Application class (sets `MapboxOptions.accessToken` at startup)                                                  
- Network security config allowing cleartext to `10.0.2.2` / `localhost` for emulator → local FastAPI                                                      
                                                      
**Tests**                                                                     
- 26 JVM unit tests: `OptimizeRouteRequest` snake_case round-trip, `OptimizedRoute` parsing including the no-route branch, `OptimizationPriority.toBackendMode`, `NetworkMonitor` distinct + reconnect-detector edge cases, `ApiRouteRepository` mapping (1-based stop indices, sale-price handling, image / slug propagation, error propagation)